### PR TITLE
317 allow fitting rnn to each region separately can use flag as argument for separate regions vs all together

### DIFF
--- a/params/dependency_graph.json
+++ b/params/dependency_graph.json
@@ -13,7 +13,8 @@
                 "blech_units_plot.py"
             ],
             "utils/qa_utils/unit_similarity.py": "blech_post_process.py",
-            "utils/qa_utils/drift_check.py": "blech_post_process.py"
+            "utils/qa_utils/drift_check.py": "blech_post_process.py",
+            "utils/infer_rnn_rates.py": "blech_make_arrays.py"
         },
         "emg/": {
             "emg_freq_setup.py": "emg_filter.py",

--- a/utils/blech_utils.py
+++ b/utils/blech_utils.py
@@ -92,10 +92,14 @@ def log_wait(func):
             try:
                 func(*args, **kwargs)
                 break
-            except:
+            except Exception as e:
+                print(f'Exception : {e}')
                 print(
                     f'Unable to access log with func : {func.__name__}, waiting {wait_time} seconds')
                 time.sleep(wait_time)
+            else:
+                raise Exception(
+                    f'Unable to access log with func : {func.__name__}')
     return wrapper
 
 
@@ -111,7 +115,7 @@ class pipeline_graph_check():
 
     def __init__(self, data_dir):
         self.data_dir = data_dir
-        # self.tee = Tee(data_dir)
+        self.tee = Tee(data_dir)
         self.load_graph()
         self.get_git_info()
         self.check_graph()
@@ -143,7 +147,6 @@ class pipeline_graph_check():
         """
         this_path_handler = path_handler()
         self.blech_clust_dir = this_path_handler.blech_clust_dir
-        # self.blech_clust_dir = '/home/abuzarmahmood/Desktop/blech_clust'
         graph_path = os.path.join(
             self.blech_clust_dir,
             'params',

--- a/utils/ephys_data/ephys_data.py
+++ b/utils/ephys_data/ephys_data.py
@@ -791,9 +791,14 @@ class ephys_data():
                                 'acceptable options are' +
                                 '\n' + f"===> {self.region_names, 'all'}")
             else:
-                this_region_units = self.region_units[region_ind[0]]
-                region_spikes = [x[:, this_region_units] for x in self.spikes]
-                return np.array(region_spikes)
+                if region_ind[0] < len(self.region_units):
+                    this_region_units = self.region_units[region_ind[0]]
+                    region_spikes = [x[:, this_region_units]
+                                     for x in self.spikes]
+                    return np.array(region_spikes)
+                else:
+                    print(f'No units found in this region: {region_name}')
+                    return None
         else:
             return np.array(self.spikes)
 

--- a/utils/infer_rnn_rates.py
+++ b/utils/infer_rnn_rates.py
@@ -109,8 +109,6 @@ from src.model import autoencoderRNN  # noqa
 loss_name = 'mse'
 
 output_path = os.path.join(data_dir, 'rnn_output')
-if args.separate_regions:
-    output_path = os.path.join(output_path, 'regions')
 artifacts_dir = os.path.join(output_path, 'artifacts')
 plots_dir = os.path.join(output_path, 'plots')
 
@@ -141,10 +139,11 @@ if args.separate_regions:
     spike_arrays = [spike_arrays[i] for i in keep_inds]
     print(f'Processing regions: {region_names}')
     # Product of region and taste indices
-    processing_inds = list(product(range(len(region_names)), range(len(spike_arrays[0]))))
+    processing_inds = list(
+        product(range(len(region_names)), range(len(spike_arrays[0]))))
     # processing_items = list(enumerate(zip(region_names, spike_arrays)))
-    processing_items = [(taste_ind, (region_names[region_ind], spike_arrays[region_ind][taste_ind])) \
-            for region_ind, taste_ind in processing_inds]
+    processing_items = [(taste_ind, (region_names[region_ind], spike_arrays[region_ind][taste_ind]))
+                        for region_ind, taste_ind in processing_inds]
 else:
     print('Processing all regions together')
     spike_array = np.stack(data.spikes)
@@ -167,12 +166,8 @@ for idx, (name, spike_data) in processing_items:
 
     iden_str = f'{name}_taste_{idx}'
 
-    if args.separate_regions:
-        print(f'Processing region {name}, taste {idx}')
-        model_name = f'region_{name}_taste_{idx}_hidden_{hidden_size}_loss_{loss_name}'
-    else:
-        print(f'Processing taste {idx}')
-        model_name = f'taste_{idx}_hidden_{hidden_size}_loss_{loss_name}'
+    print(f'Processing region {name}, taste {idx}')
+    model_name = f'region_{name}_taste_{idx}_hidden_{hidden_size}_loss_{loss_name}'
     model_save_path = os.path.join(artifacts_dir, f'{model_name}.pt')
 
     # taste_spikes = np.concatenate(spike_array)
@@ -641,11 +636,10 @@ with tables.open_file(hdf5_path, 'r+') as hf5:
         hf5.create_group('/', 'rnn_output', 'RNN Output')
     rnn_output = hf5.get_node('/rnn_output')
 
-    if args.separate_regions:
-        if '/rnn_output/regions' not in hf5:
-            hf5.create_group('/rnn_output', 'regions',
-                             'Region-specific RNN Output')
-        rnn_output = hf5.get_node('/rnn_output/regions')
+    if '/rnn_output/regions' not in hf5:
+        hf5.create_group('/rnn_output', 'regions',
+                         'Region-specific RNN Output')
+    rnn_output = hf5.get_node('/rnn_output/regions')
 
     # Write out latents and predicted firing rates
     for idx, (name, _) in processing_items:

--- a/utils/infer_rnn_rates.py
+++ b/utils/infer_rnn_rates.py
@@ -159,9 +159,9 @@ for idx, (name, spike_data) in processing_items:
     # taste_spikes = np.concatenate(spike_array)
     # Cut taste_spikes to time limits
     # Shape: (trials, neurons, time)
-    taste_spikes = taste_spikes[..., time_lims[0]:time_lims[1]]
+    spike_data = spike_data[..., time_lims[0]:time_lims[1]]
 
-    trial_num = np.arange(taste_spikes.shape[0])
+    trial_num = np.arange(spike_data.shape[0])
 
     # Bin spikes
     # (tastes x trials, neurons, time)
@@ -254,7 +254,7 @@ for idx, (name, spike_data) in processing_items:
                        zscore_bool=False,)
     fig = plt.gcf()
     plt.suptitle('RNN Inputs')
-    fig.savefig(os.path.join(plots_dir, f'inputs_taste_{taste_ind}.png'))
+    fig.savefig(os.path.join(plots_dir, f'inputs_taste_{idx}.png'))
     plt.close(fig)
 
     ############################################################
@@ -310,9 +310,9 @@ for idx, (name, spike_data) in processing_items:
         dropout=0.2,
     )
 
-    loss_path = os.path.join(artifacts_dir, f'loss_taste_{taste_ind}.json')
+    loss_path = os.path.join(artifacts_dir, f'loss_taste_{idx}.json')
     cross_val_loss_path = os.path.join(
-        artifacts_dir, f'cross_val_loss_taste_{taste_ind}.json')
+        artifacts_dir, f'cross_val_loss_taste_{idx}.json')
     if (not os.path.exists(model_save_path)) or args.retrain:
         if args.retrain:
             print('Retraining model')
@@ -406,7 +406,7 @@ for idx, (name, spike_data) in processing_items:
         bbox_to_anchor=(1.05, 1),
         loc='upper left', borderaxespad=0.)
     ax.set_title(f'Losses')
-    fig.savefig(os.path.join(plots_dir, f'run_loss_taste_{taste_ind}.png'),
+    fig.savefig(os.path.join(plots_dir, f'run_loss_taste_{idx}.png'),
                 bbox_inches='tight')
     plt.close(fig)
 
@@ -414,13 +414,13 @@ for idx, (name, spike_data) in processing_items:
     vz.firing_overview(pred_firing.swapaxes(0, 1))
     fig = plt.gcf()
     plt.suptitle('RNN Predicted Firing Rates')
-    fig.savefig(os.path.join(plots_dir, f'firing_pred_taste_{taste_ind}.png'))
+    fig.savefig(os.path.join(plots_dir, f'firing_pred_taste_{idx}.png'))
     plt.close(fig)
     vz.firing_overview(binned_spikes.swapaxes(0, 1))
     fig = plt.gcf()
     plt.suptitle('Binned Firing Rates')
     fig.savefig(os.path.join(
-        plots_dir, f'firing_binned_taste_{taste_ind}.png'))
+        plots_dir, f'firing_binned_taste_{idx}.png'))
     plt.close(fig)
 
     # Latent factors
@@ -430,7 +430,7 @@ for idx, (name, spike_data) in processing_items:
         ax[i].imshow(latent_outs[..., i].T, aspect='auto')
     plt.suptitle('Latent Factors')
     fig.savefig(os.path.join(
-        plots_dir, f'latent_factors_taste_{taste_ind}.png'))
+        plots_dir, f'latent_factors_taste_{idx}.png'))
     plt.close(fig)
 
     # Mean firing rates
@@ -442,7 +442,7 @@ for idx, (name, spike_data) in processing_items:
     ax[1].imshow(binned_spikes_mean, aspect='auto', interpolation='none')
     ax[0].set_title('Pred')
     ax[1].set_title('True')
-    fig.savefig(os.path.join(plots_dir, f'mean_firing_taste_{taste_ind}.png'))
+    fig.savefig(os.path.join(plots_dir, f'mean_firing_taste_{idx}.png'))
     plt.close(fig)
     # plt.show()
 
@@ -454,7 +454,7 @@ for idx, (name, spike_data) in processing_items:
     ax[0].set_title('Pred')
     ax[1].set_title('True')
     fig.savefig(os.path.join(
-        plots_dir, f'mean_firing_zscored_taste_{taste_ind}.png'))
+        plots_dir, f'mean_firing_zscored_taste_{idx}.png'))
     plt.close(fig)
 
     # For every neuron, plot 1) spike raster, 2) convolved firing rate ,
@@ -492,7 +492,7 @@ for idx, (name, spike_data) in processing_items:
         ax[2].set_title('RNN Predicted Firing Rate')
         fig.savefig(
             os.path.join(ind_plot_dir,
-                         f'neuron_{i}_taste_{taste_ind}_raster_conv_pred.png')
+                         f'neuron_{i}_taste_{idx}_raster_conv_pred.png')
         )
         plt.close(fig)
 
@@ -507,7 +507,7 @@ for idx, (name, spike_data) in processing_items:
         ax[0].set_title(f'Latent factors for trial {i}')
         ax[1].plot(zscore(latent_outs[1:, i], axis=0), alpha=0.5)
         fig.savefig(os.path.join(trial_latent_dir,
-                    f'taste_{taste_ind}_trial_{i}_latent.png'))
+                    f'taste_{idx}_trial_{i}_latent.png'))
         plt.close(fig)
 
 ############################################################

--- a/utils/infer_rnn_rates.py
+++ b/utils/infer_rnn_rates.py
@@ -54,7 +54,15 @@ data_dir = args.data_dir
 # data_dir = '/media/fastdata/Thomas_Data/data/sorted_new/EB13/Day3Exp120trl_230529_110345'
 script_path = os.path.abspath(__file__)
 blech_clust_path = os.path.dirname(os.path.dirname(script_path))
+sys.path.append(blech_clust_path)  # noqa
+from utils.blech_utils import entry_checker, imp_metadata, pipeline_graph_check  # noqa
 # blech_clust_path = '/home/abuzarmahmood/Desktop/blech_clust'
+
+metadata_handler = imp_metadata([[], args.data_dir])
+# Perform pipeline graph check
+this_pipeline_check = pipeline_graph_check(args.data_dir)
+this_pipeline_check.check_previous(script_path)
+this_pipeline_check.write_to_log(script_path, 'attempted')
 
 if args.override_config:
     print('Overriding config file\nUsing provided arguments\n')
@@ -703,3 +711,6 @@ with tables.open_file(hdf5_path, 'r+') as hf5:
         hf5.create_array(taste_grp, 'pred_firing', pred_firing_list[idx])
         hf5.create_array(taste_grp, 'latent_out', latent_out_list[idx])
         hf5.create_array(taste_grp, 'pred_x', pred_x_list[idx])
+
+# Write successful execution to log
+this_pipeline_check.write_to_log(script_path, 'completed')

--- a/utils/infer_rnn_rates.py
+++ b/utils/infer_rnn_rates.py
@@ -166,8 +166,8 @@ for idx, (name, spike_data) in processing_items:
     # Bin spikes
     # (tastes x trials, neurons, time)
     # for example : (120, 35, 280)
-    binned_spikes = np.reshape(taste_spikes,
-                               (*taste_spikes.shape[:2], -1, bin_size)).sum(-1)
+    binned_spikes = np.reshape(spike_data,
+                               (*spike_data.shape[:2], -1, bin_size)).sum(-1)
     binned_spikes_list.append(binned_spikes)
 
     # ** The naming of inputs / labels throughouts is confusing as hell
@@ -469,16 +469,16 @@ for idx, (name, spike_data) in processing_items:
     conv_kern = np.ones(250) / 250
     conv_rate = np.apply_along_axis(
         lambda m: np.convolve(m, conv_kern, mode='valid'),
-        axis=-1, arr=taste_spikes)*bin_size
+        axis=-1, arr=spike_data)*bin_size
     conv_x = np.convolve(
-        np.arange(taste_spikes.shape[-1]), conv_kern, mode='valid')
+        np.arange(spike_data.shape[-1]), conv_kern, mode='valid')
     conv_rate_list.append(conv_rate)
     conv_x_list.append(conv_x)
 
     for i in range(binned_spikes.shape[1]):
         fig, ax = plt.subplots(3, 1, figsize=(10, 10),
                                sharex=True, sharey=False)
-        ax[0] = vz.raster(ax[0], taste_spikes[:, i], marker='|')
+        ax[0] = vz.raster(ax[0], spike_data[:, i], marker='|')
         ax[1].plot(conv_x, conv_rate[:, i].T, c='k', alpha=0.1)
         # ax[2].plot(binned_x, binned_spikes[:,i].T, label = 'True')
         ax[2].plot(binned_x[1:], pred_firing[:, i].T,

--- a/utils/infer_rnn_rates.py
+++ b/utils/infer_rnn_rates.py
@@ -281,7 +281,7 @@ for idx, (name, spike_data) in processing_items:
                        zscore_bool=False,)
     fig = plt.gcf()
     plt.suptitle('RNN Inputs')
-    fig.savefig(os.path.join(plots_dir, f'inputs_taste_{idx}.png'))
+    fig.savefig(os.path.join(plots_dir, f'inputs_{iden_str}.png'))
     plt.close(fig)
 
     ############################################################

--- a/utils/infer_rnn_rates.py
+++ b/utils/infer_rnn_rates.py
@@ -358,6 +358,7 @@ for idx, (name, spike_data) in processing_items:
         with open(os.path.join(artifacts_dir, 'params.json'), 'w') as f:
             json.dump(params_dict, f)
     else:
+        print('Model already exists. Loading model')
         net = torch.load(model_save_path)
         # loss = np.load(loss_path, allow_pickle = True)
         # cross_val_loss = np.load(cross_val_loss_path, allow_pickle = True)


### PR DESCRIPTION
- **feat: Add support for region-specific RNN training with optional flag**
- **refactor: Replace undefined variables with correct loop variables**
- **fix: Replace undefined 'taste_spikes' with 'spike_data' in infer_rnn_rates.py**
- **fix(ephys_data): handle out-of-bounds region index for spikes retrieval**
- **fix(utils): handle None entries in region spikes processing**
- **refactor: Enhance processing of regions and tastes with improved indexing and logging**
- **refactor(utils): remove conditional checks for separate regions**
- **refactor(utils): streamline rnn rate inference and plotting**
