### PR TITLE
341 allow option to either separately train on different tastes or train on all tastes together for infer rnn rates

### DIFF
--- a/pipeline_testing/prefect_pipeline.py
+++ b/pipeline_testing/prefect_pipeline.py
@@ -365,7 +365,7 @@ def run_gapes_Li(data_dir):
 
 
 @task(log_prints=True)
-def run_rnn(data_dir, separate_regions=False):
+def run_rnn(data_dir, separate_regions=False, separate_tastes=False):
     """Run RNN firing rate inference"""
     script_name = 'utils/infer_rnn_rates.py'
     # Use 100 training steps for testing
@@ -373,6 +373,8 @@ def run_rnn(data_dir, separate_regions=False):
             "--train_steps", "100", "--retrain"]
     if separate_regions:
         args.append("--separate_regions")
+    if separate_tastes:
+        args.append("--separate_tastes")
     process = Popen(args,
                     stdout=PIPE, stderr=PIPE)
     stdout, stderr = process.communicate()
@@ -418,8 +420,10 @@ def run_spike_test(data_dir):
     quality_assurance(data_dir)
     units_plot(data_dir)
     units_characteristics(data_dir)
-    run_rnn(data_dir, separate_regions=False)
-    run_rnn(data_dir, separate_regions=True)
+    run_rnn(data_dir, separate_regions=False,   separate_tastes=False)
+    run_rnn(data_dir, separate_regions=True,    separate_tastes=False)
+    run_rnn(data_dir, separate_regions=False,   separate_tastes=True)
+    run_rnn(data_dir, separate_regions=True,    separate_tastes=True)
 
 
 @flow(log_prints=True)

--- a/utils/infer_rnn_rates.py
+++ b/utils/infer_rnn_rates.py
@@ -12,8 +12,12 @@ This module uses an Auto-regressive Recurrent Neural Network (RNN) to infer firi
 
 import argparse  # noqa: E402
 import os  # noqa
-test_mode = True
+test_mode = False
 if test_mode:
+
+    print('====================')
+    print('Running in test mode')
+    print('====================')
     # data_dir = '/media/fastdata/Thomas_Data/data/sorted_new/EB13/Day3Exp120trl_230529_110345'
     data_dir = '/media/fastdata/Thomas_Data/data/sorted_new/TG23/FlavorDay1_230625_115542'
     script_path = '/home/abuzarmahmood/Desktop/blech_clust/utils/infer_rnn_rates.py'

--- a/utils/infer_rnn_rates.py
+++ b/utils/infer_rnn_rates.py
@@ -12,16 +12,18 @@ This module uses an Auto-regressive Recurrent Neural Network (RNN) to infer firi
 
 import argparse  # noqa: E402
 import os  # noqa
-test_mode = False
+test_mode = True
 if test_mode:
 
     print('====================')
     print('Running in test mode')
     print('====================')
     # data_dir = '/media/fastdata/Thomas_Data/data/sorted_new/EB13/Day3Exp120trl_230529_110345'
-    data_dir = '/media/fastdata/Thomas_Data/data/sorted_new/TG23/FlavorDay1_230625_115542'
-    script_path = '/home/abuzarmahmood/Desktop/blech_clust/utils/infer_rnn_rates.py'
-    blech_clust_path = '/home/abuzarmahmood/Desktop/blech_clust'
+    # data_dir = '/media/fastdata/Thomas_Data/data/sorted_new/TG23/FlavorDay1_230625_115542'
+    data_dir = '/home/abuzarmahmood/projects/blech_clust/pipeline_testing/test_data_handling/test_data/KM45_5tastes_210620_113227_new'
+    # script_path = '/home/abuzarmahmood/Desktop/blech_clust/utils/infer_rnn_rates.py'
+    script_path = '/home/abuzarmahmood/projects/blech_clust/utils/infer_rnn_rates.py'
+    blech_clust_path = os.path.dirname(os.path.dirname(script_path)) 
     args = argparse.Namespace(
         data_dir=data_dir,
         train_steps=1000,
@@ -251,6 +253,14 @@ if args.separate_regions:
 
 processing_items, taste_inds, region_inds = parse_group_by(
     spikes_xr, group_by_list)
+
+# Drop any items with 'none' in region_inds
+region_inds = [x.lower() for x in region_inds]
+wanted_inds = [i for i, x in enumerate(region_inds) if x != 'none']
+region_inds = [region_inds[i] for i in wanted_inds]
+taste_inds = [taste_inds[i] for i in wanted_inds]
+processing_items = [processing_items[i] for i in wanted_inds]
+
 processing_inds = list(product(region_inds, taste_inds))
 processing_str = [f'Taste {i}, Region {j}' for j, i in processing_inds]
 

--- a/utils/infer_rnn_rates.py
+++ b/utils/infer_rnn_rates.py
@@ -23,7 +23,7 @@ if test_mode:
     data_dir = '/home/abuzarmahmood/projects/blech_clust/pipeline_testing/test_data_handling/test_data/KM45_5tastes_210620_113227_new'
     # script_path = '/home/abuzarmahmood/Desktop/blech_clust/utils/infer_rnn_rates.py'
     script_path = '/home/abuzarmahmood/projects/blech_clust/utils/infer_rnn_rates.py'
-    blech_clust_path = os.path.dirname(os.path.dirname(script_path)) 
+    blech_clust_path = os.path.dirname(os.path.dirname(script_path))
     args = argparse.Namespace(
         data_dir=data_dir,
         train_steps=1000,
@@ -192,6 +192,7 @@ def parse_group_by(spikes_xr, group_by_list):
 ############################################################
 ############################################################
 
+
 if not test_mode:
     metadata_handler = imp_metadata([[], args.data_dir])
     # Perform pipeline graph check
@@ -259,7 +260,8 @@ processing_items, processing_inds, taste_inds, region_inds = parse_group_by(
 region_inds = [x.lower() for x in region_inds]
 wanted_inds = [i for i, x in enumerate(region_inds) if x != 'none']
 region_inds = [region_inds[i] for i in wanted_inds]
-wanted_processing_inds = [i for i,x in enumerate(processing_inds) if x[0] != 'none']
+wanted_processing_inds = [i for i, x in enumerate(
+    processing_inds) if x[0] != 'none']
 processing_inds = [processing_inds[i] for i in wanted_processing_inds]
 processing_items = [processing_items[i] for i in wanted_processing_inds]
 
@@ -675,14 +677,6 @@ pred_frame = pd.DataFrame(
     )
 )
 
-if 'taste' not in group_by_list:
-    region_conv_rate_list = region_conv_rate_list[0]
-    region_pred_firing_list = region_pred_firing_list[0]
-    region_conv_rate_list = [region_conv_rate_list[cum_trial_counts[i]:cum_trial_counts[i+1]]
-                             for i in range(len(trial_counts)-1)]
-    region_pred_firing_list = [region_pred_firing_list[cum_trial_counts[i]:cum_trial_counts[i+1]]
-                               for i in range(len(trial_counts)-1)]
-
 all_pred_firing_taste = [
     [x for x in pred_frame.loc[pred_frame.region_name ==
                                region_name, 'pred_firing'].to_list()]
@@ -717,22 +711,22 @@ if 'taste' not in group_by_list:
     for this_region in region_names:
         # Binned spikes
         wanted_region_binned = pred_frame.loc[
-                pred_frame.region_name == this_region, 'binned_spikes'].to_list()[0]
+            pred_frame.region_name == this_region, 'binned_spikes'].to_list()[0]
         region_binned_taste = [wanted_region_binned[cum_trial_counts[i]:cum_trial_counts[i+1]]
-                                 for i in range(len(trial_counts)-1)]
+                               for i in range(len(trial_counts)-1)]
         # Predicted firing
         wanted_region_pred = pred_frame.loc[
-                pred_frame.region_name == this_region, 'pred_firing'].to_list()[0]
+            pred_frame.region_name == this_region, 'pred_firing'].to_list()[0]
         region_pred_taste = [wanted_region_pred[cum_trial_counts[i]:cum_trial_counts[i+1]]
-                                    for i in range(len(trial_counts)-1)]
+                             for i in range(len(trial_counts)-1)]
         # Latent factors
         wanted_region_latent = pred_frame.loc[
-                pred_frame.region_name == this_region, 'latent_out'].to_list()[0]
+            pred_frame.region_name == this_region, 'latent_out'].to_list()[0]
         region_latent_taste = [wanted_region_latent[cum_trial_counts[i]:cum_trial_counts[i+1]]
                                for i in range(len(trial_counts)-1)]
         # Convolved firing rates
         wanted_region_conv_rate = pred_frame.loc[
-                pred_frame.region_name == this_region, 'conv_rate'].to_list()[0]
+            pred_frame.region_name == this_region, 'conv_rate'].to_list()[0]
         region_conv_rate_taste = [wanted_region_conv_rate[cum_trial_counts[i]:cum_trial_counts[i+1]]
                                   for i in range(len(trial_counts)-1)]
         # Create a new frame
@@ -763,9 +757,11 @@ for this_region in region_names:
     region_taste_pred = taste_pred_frame.loc[
         taste_pred_frame.region_name == this_region, 'pred_firing'].to_list()
     # Shape: taste x neurons x time
-    region_taste_mean_binned = np.stack([x.mean(axis=0) for x in region_taste_binned])
-    region_taste_mean_pred = np.stack([x.mean(axis=0) for x in region_taste_pred])
-    region_nrn_count = region_taste_mean_binned.shape[1] 
+    region_taste_mean_binned = np.stack(
+        [x.mean(axis=0) for x in region_taste_binned])
+    region_taste_mean_pred = np.stack(
+        [x.mean(axis=0) for x in region_taste_pred])
+    region_nrn_count = region_taste_mean_binned.shape[1]
     binned_x = taste_pred_frame.loc[
         taste_pred_frame.region_name == this_region, 'binned_x'].to_list()[0]
     pred_x = taste_pred_frame.loc[
@@ -775,9 +771,9 @@ for this_region in region_names:
                                      sharex=True,)
     for nrn_ind in range(region_nrn_count):
         ax.flatten()[nrn_ind].plot(
-                binned_x, region_taste_mean_binned[:,nrn_ind].T, alpha=0.5)
+            binned_x, region_taste_mean_binned[:, nrn_ind].T, alpha=0.5)
         ax.flatten()[nrn_ind].plot(
-                pred_x, region_taste_mean_pred[:,nrn_ind].T, alpha=0.5)
+            pred_x, region_taste_mean_pred[:, nrn_ind].T, alpha=0.5)
     fig.suptitle(basename + '\n' + f'Mean Neuron Firing Rates : {this_region}')
     fig.savefig(os.path.join(
         plots_dir, f'mean_neuron_firing_{this_region}.png'))

--- a/utils/infer_rnn_rates.py
+++ b/utils/infer_rnn_rates.py
@@ -814,9 +814,9 @@ for spike_array, region_name in zip(spike_arrays, region_names):
         region_conv_rate_list = region_conv_rate_list[0]
         region_pred_firing_list = region_pred_firing_list[0]
         region_conv_rate_list = [region_conv_rate_list[cum_trial_counts[i]:cum_trial_counts[i+1]]
-                                 for i in range(len(trial_counts)-1)]
+                                 for i in range(len(cum_trial_counts)-1)]
         region_pred_firing_list = [region_pred_firing_list[cum_trial_counts[i]:cum_trial_counts[i+1]]
-                                   for i in range(len(trial_counts)-1)]
+                                   for i in range(len(cum_trial_counts)-1)]
     cmap = plt.get_cmap('tab10')
     # Iterate over neurons
     for i in range(region_nrn_count):

--- a/utils/infer_rnn_rates.py
+++ b/utils/infer_rnn_rates.py
@@ -306,7 +306,8 @@ for (name, idx), spike_data in zip(processing_inds, processing_items):
     # Bin spikes
     # (tastes x trials, neurons, time)
     # for example : (120, 35, 280)
-    spike_data = spike_data.to_numpy()
+    if 'xarray' in str(type(spike_data)):
+        spike_data = spike_data.to_numpy()
     binned_spikes = np.reshape(spike_data,
                                (*spike_data.shape[:2], -1, bin_size)).sum(-1)
     binned_spikes_list.append(binned_spikes)


### PR DESCRIPTION
- **feat(infer_rnn_rates): add separate_tastes argument and enhance region-taste processing**
- **fix(utils): correct loop indexing and processing logic in RNN rate inference**
- **refactor(infer-rnn-rates): improve argument parsing and configuration management**
- **fix(taste-indexing): resolve taste and region indexing bugs**
- **chore(utils): update test mode settings in infer_rnn_rates.py**
- **fix(utils): filter out 'none' entries in region indices**
- **refactor(utils): improve neuron firing rate prediction and plotting**
- **fix(infer_rnn_rates): improve data processing for predicted firing rates and latent outputs**
- **refactor(utils): update test mode settings and streamline data processing**
- **fix(utils): handle conversion of spike_data for different data types**
- **refactor(infer_rnn_rates): remove unused logic for 'taste' group**
