### PR TITLE
348 infer dead channels and remove them before common average reference

### DIFF
--- a/blech_common_avg_reference.py
+++ b/blech_common_avg_reference.py
@@ -103,6 +103,9 @@ hf5 = tables.open_file(metadata_handler.hdf5_name, 'r+')
 # emg is a separate group
 info_dict = metadata_handler.info_dict
 electrode_layout_frame = metadata_handler.layout
+# Pull out the raw electrode nodes of the HDF5 file
+raw_electrodes = hf5.list_nodes('/raw')
+
 # Identify dead channels
 dead_channels = identify_dead_channels(raw_electrodes)
 

--- a/blech_common_avg_reference.py
+++ b/blech_common_avg_reference.py
@@ -89,10 +89,7 @@ electrode_layout_frame = metadata_handler.layout
 # Pull out the raw electrode nodes of the HDF5 file
 raw_electrodes = hf5.list_nodes('/raw')
 
-# Identify dead channels
-dead_channels = identify_dead_channels(raw_electrodes)
-
-# Remove emg, none, and dead channels from the electrode layout frame
+# Remove emg and none channels from the electrode layout frame
 emg_bool = ~electrode_layout_frame.CAR_group.str.contains('emg')
 none_bool = ~electrode_layout_frame.CAR_group.str.contains('none')
 fin_bool = np.logical_and(emg_bool, none_bool)
@@ -106,9 +103,7 @@ all_car_group_names = [x[0] for x in grouped_layout]
 # specified in the layout file
 all_car_group_vals = [x[1].electrode_ind.values for x in grouped_layout]
 
-# Exclude dead channels from CAR groups
-CAR_electrodes = [np.setdiff1d(group, dead_channels) for group in all_car_group_vals]
-num_groups = len(CAR_electrodes)
+num_groups = len(all_car_group_vals)
 print(f" Number of groups : {num_groups}")
 for region, vals in zip(all_car_group_names, all_car_group_vals):
     print(f" {region} :: {vals}")

--- a/blech_common_avg_reference.py
+++ b/blech_common_avg_reference.py
@@ -103,7 +103,9 @@ all_car_group_names = [x[0] for x in grouped_layout]
 # specified in the layout file
 all_car_group_vals = [x[1].electrode_ind.values for x in grouped_layout]
 
-num_groups = len(all_car_group_vals)
+# Exclude dead channels from CAR groups
+CAR_electrodes = [np.setdiff1d(group, dead_channels) for group in all_car_group_vals]
+num_groups = len(CAR_electrodes)
 print(f" Number of groups : {num_groups}")
 for region, vals in zip(all_car_group_names, all_car_group_vals):
     print(f" {region} :: {vals}")

--- a/blech_common_avg_reference.py
+++ b/blech_common_avg_reference.py
@@ -52,36 +52,38 @@ import numpy as np
 def identify_dead_channels(raw_electrodes, abs_threshold=0.01, rel_threshold=0.05):
     """
     Identify dead channels based on absolute and relative variance thresholds.
-    
+
     Channels are considered dead if either:
     1. Their variance is below the absolute threshold
     2. Their variance is below rel_threshold * median variance of all channels
-    
+
     Args:
         raw_electrodes (list): List of electrode data arrays.
         abs_threshold (float): Absolute variance threshold to identify dead channels.
         rel_threshold (float): Relative variance threshold as a fraction of median variance.
-        
+
     Returns:
         list: Indices of dead channels.
     """
     # Calculate variance for all electrodes
-    variances = np.array([np.var(electrode[:]) for electrode in raw_electrodes])
-    
+    variances = np.array([np.var(electrode[:])
+                         for electrode in raw_electrodes])
+
     # Calculate median variance across all channels
     median_variance = np.median(variances)
-    
+
     # Identify dead channels using both absolute and relative thresholds
     dead_channels = []
     for i, variance in enumerate(variances):
         if variance < abs_threshold or variance < (rel_threshold * median_variance):
             dead_channels.append(i)
-            
-    print(f"Identified {len(dead_channels)} dead channels out of {len(raw_electrodes)}")
+
+    print(
+        f"Identified {len(dead_channels)} dead channels out of {len(raw_electrodes)}")
     if len(dead_channels) > 0:
         print(f"Median variance: {median_variance:.6f}")
         print(f"Relative threshold: {rel_threshold * median_variance:.6f}")
-        
+
     return dead_channels
 
 

--- a/blech_common_avg_reference.py
+++ b/blech_common_avg_reference.py
@@ -40,6 +40,24 @@ Author: Abuzar Mahmood
 # Import stuff!
 import tables
 import numpy as np
+
+def identify_dead_channels(raw_electrodes, threshold=0.01):
+    """
+    Identify dead channels based on a threshold.
+    Channels with variance below the threshold are considered dead.
+    
+    Args:
+        raw_electrodes (list): List of electrode data arrays.
+        threshold (float): Variance threshold to identify dead channels.
+        
+    Returns:
+        list: Indices of dead channels.
+    """
+    dead_channels = []
+    for i, electrode in enumerate(raw_electrodes):
+        if np.var(electrode[:]) < threshold:
+            dead_channels.append(i)
+    return dead_channels
 import os
 import easygui
 import sys

--- a/blech_common_avg_reference.py
+++ b/blech_common_avg_reference.py
@@ -40,24 +40,6 @@ Author: Abuzar Mahmood
 # Import stuff!
 import tables
 import numpy as np
-
-def identify_dead_channels(raw_electrodes, threshold=0.01):
-    """
-    Identify dead channels based on a threshold.
-    Channels with variance below the threshold are considered dead.
-    
-    Args:
-        raw_electrodes (list): List of electrode data arrays.
-        threshold (float): Variance threshold to identify dead channels.
-        
-    Returns:
-        list: Indices of dead channels.
-    """
-    dead_channels = []
-    for i, electrode in enumerate(raw_electrodes):
-        if np.var(electrode[:]) < threshold:
-            dead_channels.append(i)
-    return dead_channels
 import os
 import easygui
 import sys

--- a/blech_common_avg_reference.py
+++ b/blech_common_avg_reference.py
@@ -40,6 +40,24 @@ Author: Abuzar Mahmood
 # Import stuff!
 import tables
 import numpy as np
+
+def identify_dead_channels(raw_electrodes, threshold=0.01):
+    """
+    Identify dead channels based on a threshold.
+    Channels with variance below the threshold are considered dead.
+    
+    Args:
+        raw_electrodes (list): List of electrode data arrays.
+        threshold (float): Variance threshold to identify dead channels.
+        
+    Returns:
+        list: Indices of dead channels.
+    """
+    dead_channels = []
+    for i, electrode in enumerate(raw_electrodes):
+        if np.var(electrode[:]) < threshold:
+            dead_channels.append(i)
+    return dead_channels
 import os
 import easygui
 import sys
@@ -88,6 +106,9 @@ info_dict = metadata_handler.info_dict
 electrode_layout_frame = metadata_handler.layout
 # Pull out the raw electrode nodes of the HDF5 file
 raw_electrodes = hf5.list_nodes('/raw')
+
+# Identify dead channels
+dead_channels = identify_dead_channels(raw_electrodes)
 
 # Remove emg and none channels from the electrode layout frame
 emg_bool = ~electrode_layout_frame.CAR_group.str.contains('emg')

--- a/blech_common_avg_reference.py
+++ b/blech_common_avg_reference.py
@@ -49,22 +49,39 @@ import tables
 import numpy as np
 
 
-def identify_dead_channels(raw_electrodes, threshold=0.01):
+def identify_dead_channels(raw_electrodes, abs_threshold=0.01, rel_threshold=0.05):
     """
-    Identify dead channels based on a threshold.
-    Channels with variance below the threshold are considered dead.
-
+    Identify dead channels based on absolute and relative variance thresholds.
+    
+    Channels are considered dead if either:
+    1. Their variance is below the absolute threshold
+    2. Their variance is below rel_threshold * median variance of all channels
+    
     Args:
         raw_electrodes (list): List of electrode data arrays.
-        threshold (float): Variance threshold to identify dead channels.
-
+        abs_threshold (float): Absolute variance threshold to identify dead channels.
+        rel_threshold (float): Relative variance threshold as a fraction of median variance.
+        
     Returns:
         list: Indices of dead channels.
     """
+    # Calculate variance for all electrodes
+    variances = np.array([np.var(electrode[:]) for electrode in raw_electrodes])
+    
+    # Calculate median variance across all channels
+    median_variance = np.median(variances)
+    
+    # Identify dead channels using both absolute and relative thresholds
     dead_channels = []
-    for i, electrode in enumerate(raw_electrodes):
-        if np.var(electrode[:]) < threshold:
+    for i, variance in enumerate(variances):
+        if variance < abs_threshold or variance < (rel_threshold * median_variance):
             dead_channels.append(i)
+            
+    print(f"Identified {len(dead_channels)} dead channels out of {len(raw_electrodes)}")
+    if len(dead_channels) > 0:
+        print(f"Median variance: {median_variance:.6f}")
+        print(f"Relative threshold: {rel_threshold * median_variance:.6f}")
+        
     return dead_channels
 
 

--- a/blech_common_avg_reference.py
+++ b/blech_common_avg_reference.py
@@ -38,18 +38,26 @@ Author: Abuzar Mahmood
 """
 
 # Import stuff!
+import os
+from utils.blech_utils import imp_metadata, pipeline_graph_check
+import json
+import glob
+from tqdm import tqdm
+import sys
+import easygui
 import tables
 import numpy as np
+
 
 def identify_dead_channels(raw_electrodes, threshold=0.01):
     """
     Identify dead channels based on a threshold.
     Channels with variance below the threshold are considered dead.
-    
+
     Args:
         raw_electrodes (list): List of electrode data arrays.
         threshold (float): Variance threshold to identify dead channels.
-        
+
     Returns:
         list: Indices of dead channels.
     """
@@ -58,14 +66,6 @@ def identify_dead_channels(raw_electrodes, threshold=0.01):
         if np.var(electrode[:]) < threshold:
             dead_channels.append(i)
     return dead_channels
-import os
-import easygui
-import sys
-from tqdm import tqdm
-import glob
-import json
-from utils.blech_utils import imp_metadata, pipeline_graph_check
-import numpy as np
 
 
 def get_electrode_by_name(raw_electrodes, name):
@@ -125,7 +125,8 @@ all_car_group_names = [x[0] for x in grouped_layout]
 all_car_group_vals = [x[1].electrode_ind.values for x in grouped_layout]
 
 # Exclude dead channels from CAR groups
-CAR_electrodes = [np.setdiff1d(group, dead_channels) for group in all_car_group_vals]
+CAR_electrodes = [np.setdiff1d(group, dead_channels)
+                  for group in all_car_group_vals]
 num_groups = len(CAR_electrodes)
 print(f" Number of groups : {num_groups}")
 for region, vals in zip(all_car_group_names, all_car_group_vals):

--- a/blech_common_avg_reference.py
+++ b/blech_common_avg_reference.py
@@ -60,23 +60,6 @@ def get_electrode_by_name(raw_electrodes, name):
         x for x in raw_electrodes if str_name in x._v_pathname][0]
     return wanted_electrode_ind
 
-def identify_dead_channels(raw_electrodes, threshold=0.01):
-    """
-    Identify dead channels based on a threshold.
-    Channels with variance below the threshold are considered dead.
-    
-    Args:
-        raw_electrodes (list): List of electrode data arrays.
-        threshold (float): Variance threshold to identify dead channels.
-        
-    Returns:
-        list: Indices of dead channels.
-    """
-    dead_channels = []
-    for i, electrode in enumerate(raw_electrodes):
-        if np.var(electrode[:]) < threshold:
-            dead_channels.append(i)
-    return dead_channels
 ############################################################
 
 


### PR DESCRIPTION
- **feat: Integrate dead channel identification and exclusion in CAR calculation**
- **fix: Define raw_electrodes before using it to identify dead channels**
- **feat: Implement dead channel identification and exclusion in CAR calculation**
- **feat: Define identify_dead_channels function to identify dead channels**
- **feat: Add function to identify and exclude dead channels before CAR calculation**
- **refactor: Remove dead channel identification from electrode layout processing**
- **fix: Define CAR_electrodes to resolve undefined name error in loop**
- **fix: Define dead_channels to resolve undefined name error in CAR calculation**
