### PR TITLE
Fix elbo_drift.py warnings

### DIFF
--- a/utils/qa_utils/elbo_drift.py
+++ b/utils/qa_utils/elbo_drift.py
@@ -332,7 +332,7 @@ for i, n_change in enumerate(changes_vec):
     for row_ind, this_row in this_frame.iterrows():
         for c_i, this_mode in enumerate(this_row['mode']):
             ax[i+1, 2].scatter(bins[this_mode], this_row['repeat'],
-                               c=change_colors[c_i], cmap='tab10')
+                               color=change_colors[c_i], cmap='tab10')
     for this_change in range(tau_hists.shape[1]):
         ax[i+1, 2] = ridge_plot(
             bins[:-1],


### PR DESCRIPTION
Changed `c=` to `color=` in line 335 in order to stop producing the warning: 
`*c* argument looks like a single numeric RGB or RGBA sequence, which should be avoided as value-mapping will have precedence in case its length matches with *x* & *y*.  Please use the *color* keyword-argument or provide a 2-D array with a single row if you intend to specify the same RGB or RGBA value for all points.`