### PR TITLE
Update emg plotting to work with multiple opto conditions

### DIFF
--- a/blech_make_arrays.py
+++ b/blech_make_arrays.py
@@ -129,7 +129,6 @@ if __name__ == '__main__':
         data_dir = '/media/storage/NM_resorted_data/NM43/NM43_500ms_160510_125413'
         metadata_handler = imp_metadata([[], data_dir])
     else:
-
         metadata_handler = imp_metadata(sys.argv)
 
         # Perform pipeline graph check

--- a/emg/emg_freq_plot.py
+++ b/emg/emg_freq_plot.py
@@ -150,13 +150,22 @@ for plot_name, plot_data in zip(['gapes', 'ltps'], [gapes, ltps]):
 
 # Plot taste overlay per laser condition and CAR
 print('Plotting Taste and Laser Overlay...')
+
+# Downsample
+bin_size = 25
+mean_emg_long['bin'] = mean_emg_long['time'] // bin_size
+
+# Average over bins
+mean_emg_long = mean_emg_long.groupby(
+    ['car', 'taste', 'laser_tuple', 'emg_type', 'bin']).mean().reset_index()
+
 for car_name, car_dat in list(mean_emg_long.groupby('car')):
     g = sns.relplot(
         data=mean_emg_long,
         x='time',
         y='emg_value',
         hue='taste',
-        row='laser',
+        row='laser_tuple',
         col='emg_type',
         # style = 'emg_type',
         kind='line',
@@ -181,7 +190,7 @@ for car_name, car_dat in list(mean_emg_long.groupby('car')):
         data=mean_emg_long,
         x='time',
         y='emg_value',
-        hue='laser',
+        hue='laser_tuple',
         row='emg_type',
         col='taste',
         # style = 'emg_type',

--- a/emg/emg_freq_plot.py
+++ b/emg/emg_freq_plot.py
@@ -31,14 +31,22 @@ from utils.blech_utils import imp_metadata  # noqa: E402
 
 # Ask for the directory where the hdf5 file sits, and change to that directory
 # Get name of directory with the data files
-metadata_handler = imp_metadata(sys.argv)
+test_bool = False
+
+if test_bool:
+    data_dir = '/media/storage/NM_resorted_data/NM43/NM43_500ms_160510_125413'
+    metadata_handler = imp_metadata([[], data_dir])
+else:
+    metadata_handler = imp_metadata(sys.argv)
+
 dir_name = metadata_handler.dir_name
 info_dict = metadata_handler.info_dict
 params_dict = metadata_handler.params_dict
 os.chdir(dir_name)
 
 emg_merge_df = pd.read_csv('emg_output/emg_env_merge_df.csv', index_col=0)
-emg_merge_df['laser'].fillna(False, inplace=True)
+emg_merge_df['laser_tuple'] = emg_merge_df.apply(
+    lambda x: (x['laser_duration_ms'], x['laser_lag_ms']), axis=1)
 
 gapes = np.load('emg_output/gape_array.npy')
 ltps = np.load('emg_output/ltp_array.npy')
@@ -52,18 +60,20 @@ plot_indices = np.where((x >= -time_limits[0])*(x <= time_limits[1]))[0]
 
 plot_gapes = gapes[:, plot_indices]
 plot_ltps = ltps[:, plot_indices]
-plot_x = [x[plot_indices]]*len(gapes)
+plot_x = np.stack([x[plot_indices]]*len(gapes))
+
+print('Gathering EMG data...')
 
 # Multi-column explode is not available in current pandas
 # Add time, gapes, and ltps to the dataframe manually
 fin_frame_list = []
 for i in trange(len(emg_merge_df)):
-    this_frame = emg_merge_df.iloc[i]
-    this_dict = this_frame.to_dict()
-    this_dict['time'] = plot_x[i]
-    this_dict['gapes'] = plot_gapes[i]
-    this_dict['ltps'] = plot_ltps[i]
-    fin_frame_list.append(pd.DataFrame(this_dict))
+    this_frame = pd.DataFrame(
+        [emg_merge_df.iloc[i]]*len(plot_gapes[i]))
+    this_frame['time'] = plot_x[i]
+    this_frame['gapes'] = plot_gapes[i]
+    this_frame['ltps'] = plot_ltps[i]
+    fin_frame_list.append(this_frame)
 
 emg_merge_df_long = pd.concat(fin_frame_list, axis=0)
 
@@ -76,7 +86,7 @@ emg_merge_df_long = pd.melt(
     value_name='emg_value')
 
 mean_emg_long = emg_merge_df_long.groupby(
-    ['car', 'taste', 'laser', 'emg_type', 'time']).mean().reset_index()
+    ['car', 'taste', 'laser_tuple', 'emg_type', 'time']).mean().reset_index()
 
 ############################################################
 # Plotting
@@ -93,12 +103,14 @@ plot_dir = os.path.join(
 if not os.path.exists(plot_dir):
     os.makedirs(plot_dir)
 
+print('Plotting Gap and LTPS data...')
+
 # plot_data = gapes.copy()
 # Plot Grid
 for plot_name, plot_data in zip(['gapes', 'ltps'], [gapes, ltps]):
     car_list = [x[1] for x in list(emg_merge_df.groupby('car'))]
     for this_car in car_list:
-        taste_laser_groups = list(this_car.groupby(['taste', 'laser']))
+        taste_laser_groups = list(this_car.groupby(['taste', 'laser_tuple']))
         taste_laser_inds = [x[0] for x in taste_laser_groups]
         taste_laser_data = [x[1] for x in taste_laser_groups]
         n_tastes = this_car['taste'].nunique()
@@ -135,7 +147,9 @@ for plot_name, plot_data in zip(['gapes', 'ltps'], [gapes, ltps]):
             bbox_inches='tight')
         plt.close(fig)
 
+
 # Plot taste overlay per laser condition and CAR
+print('Plotting Taste and Laser Overlay...')
 for car_name, car_dat in list(mean_emg_long.groupby('car')):
     g = sns.relplot(
         data=mean_emg_long,


### PR DESCRIPTION
### TL;DR

Added test mode to EMG frequency plotting and improved data handling for laser parameters.

### What changed?

- Added a test mode to `emg_freq_plot.py` similar to what exists in `blech_make_arrays.py`
- Changed how laser data is handled by creating a `laser_tuple` column that combines duration and lag parameters
- Improved the data frame creation process for EMG data by using vectorized operations
- Added progress messages during processing steps
- Fixed array handling for `plot_x` by using `np.stack` instead of list multiplication
- Updated groupby operations to use the new `laser_tuple` column instead of just `laser`

### How to test?

1. Run the EMG frequency plotting script with test mode enabled (`test_bool = True`)
2. Verify that plots are generated correctly with the new laser parameter handling
3. Check that the script works with both test data and when providing arguments via command line

### Why make this change?

These changes improve the handling of laser parameters by preserving both duration and lag information in the analysis. The test mode makes debugging easier by allowing the script to run with predefined data. The code also runs more efficiently with the improved data frame creation process and provides better user feedback with progress messages.