### PR TITLE
Update blech_post_process_utils.py

### DIFF
--- a/blech_post_process.py
+++ b/blech_post_process.py
@@ -189,7 +189,6 @@ elif sorted_units_exist_bool:
 else:
     hf5.create_group('/', 'sorted_units')
 
-
 ############################################################
 # Main Processing Loop
 ############################################################

--- a/blech_process.py
+++ b/blech_process.py
@@ -334,13 +334,22 @@ for cluster_num, fit_type in iters:
     )
     # Use the new simplified clustering method
     cluster_handler.perform_clustering()
+    cluster_handler.ensure_continuous_labels()
+
     # At this point, cluster_handler has a trained GMM
     # If 'throw_out_noise', then get labels for all waveforms
+    # otherwise, use the labels from the GMM
     if throw_out_noise_bool:
         print('=== GMM trained using only classified spikes ===')
         all_labels = cluster_handler.get_cluster_labels(
             all_features,
         )
+        # Since GMM will return predictions using original labels,
+        # if auto_clustering, will need to relabel
+        if auto_cluster:
+            all_labels = np.array(
+                [cluster_handler.cluster_map[label] for label in all_labels]
+            )
     else:
         all_labels = cluster_handler.labels
     cluster_handler.remove_outliers(params_dict)

--- a/utils/blech_post_process_utils.py
+++ b/utils/blech_post_process_utils.py
@@ -89,8 +89,8 @@ class sort_file_handler():
 
             # Get splits and merges out of the way first
             sort_table.sort_values(
-                ['len_cluster', 'Split'],
-                ascending=False, inplace=True)
+                    ['len_cluster','Split'],
+                    ascending=False, inplace=True)
             if 'level_0' in sort_table.columns:
                 sort_table.drop(columns=['level_0'], inplace=True)
             sort_table.reset_index(inplace=True)
@@ -286,7 +286,6 @@ def generate_cluster_plots(
 
     plt.tight_layout()
     plt.show()
-
 
 def get_clustering_params(this_sort_file_handler):
     """

--- a/utils/blech_post_process_utils.py
+++ b/utils/blech_post_process_utils.py
@@ -587,7 +587,7 @@ def gen_plot_auto_merged_clusters(
                             for this_text, this_count in zip(
                                 current_legend_texts,
                                 waveform_counts,
-                            )]
+        )]
         for this_text, new_text in zip(
                 current_legend_texts,
                 new_legend_texts,


### PR DESCRIPTION
Update blech_post_process_utils.py

1: set up wiping of the 'level_0' column on re-runs
2: added "press q" to some of the plots as a tip
3: set up importing of the value of `Split` column to be used to determine # of splits

Update blech_post_process.py

Add an option to clear preexisting saved units when re-running post_process

[pre-commit.ci] auto fixes from pre-commit.com hooks

for more information, see https://pre-commit.ci

refactor(clustering): simplify and ensure continuous cluster labeling

- Added `ensure_continuous_labels` method to `cluster_handler` class for consistent label naming.
- Revised logic in `blech_process.py` to use the new method for label continuity.
- Refactored and moved label continuity logic from `remove_outliers` to the new dedicated method.
- Improved code readability and maintainability by organizing clustering-related functionality.

Merge branch '04-29-use_units_plot_for_blech_process' of https://github.com/katzlabbrandeis/blech_clust into 447-issue-with-numbering-of-plots-for-blech_process