### PR TITLE
refactor: perform filtering before CAR

### DIFF
--- a/blech_make_arrays.py
+++ b/blech_make_arrays.py
@@ -406,6 +406,8 @@ if __name__ == '__main__':
         for this_el in tqdm(raw_emg_electrodes):
             raw_el = this_el[:]
             # High bandpass filter the raw electrode recordings
+            # NOTE: This filtered electrode is NOT USED downstream,
+            # don't worry about filtering EMG electrode with non-emg frequencies
             filt_el = get_filtered_electrode(
                 raw_el,
                 freq=[params_dict['bandpass_lower_cutoff'],

--- a/utils/blech_process_utils.py
+++ b/utils/blech_process_utils.py
@@ -888,7 +888,7 @@ class electrode_handler():
         5. Apply cutoff to electrode data
         """
         # Filter electrode
-        self.filter_electrode()
+        # self.filter_electrode()
 
         # Cut to integer seconds
         self.cut_to_int_seconds()
@@ -904,15 +904,15 @@ class electrode_handler():
 
         return self.filt_el
 
-    def filter_electrode(self):
-        # Raw units get multiplied by 0.195 to get MICROVOLTS
-        self.filt_el = clust.get_filtered_electrode(
-            self.raw_el,
-            freq=[self.params_dict['bandpass_lower_cutoff'],
-                  self.params_dict['bandpass_upper_cutoff']],
-            sampling_rate=self.params_dict['sampling_rate'],)
-        # Delete raw electrode recording from memory
-        del self.raw_el
+    # def filter_electrode(self):
+    #     # Raw units get multiplied by 0.195 to get MICROVOLTS
+    #     self.filt_el = clust.get_filtered_electrode(
+    #         self.raw_el,
+    #         freq=[self.params_dict['bandpass_lower_cutoff'],
+    #               self.params_dict['bandpass_upper_cutoff']],
+    #         sampling_rate=self.params_dict['sampling_rate'],)
+    #     # Delete raw electrode recording from memory
+    #     del self.raw_el
 
     def adjust_to_sampling_rate(data, sampling_rate):
         return

--- a/utils/clustering.py
+++ b/utils/clustering.py
@@ -13,22 +13,12 @@ This module provides functions for processing and analyzing electrophysiological
 - `clusterGMM(data, n_clusters, n_iter, restarts, threshold)`: Clusters data using Gaussian Mixture Models (GMM), returning the best model, predictions, and Bayesian Information Criterion (BIC) score.
 """
 import numpy as np
-from scipy.signal import butter
-from scipy.signal import filtfilt
 from scipy.interpolate import interp1d
 from sklearn.mixture import GaussianMixture
 import pylab as plt
 from sklearn.decomposition import PCA
 from scipy.signal import fftconvolve
 from sklearn.cluster import KMeans
-
-
-def get_filtered_electrode(data, freq=[300.0, 3000.0], sampling_rate=30000.0):
-    el = 0.195*(data)
-    m, n = butter(2, [2.0*freq[0]/sampling_rate, 2.0 *
-                  freq[1]/sampling_rate], btype='bandpass')
-    filt_el = filtfilt(m, n, el)
-    return filt_el
 
 
 def extract_waveforms_abu(filt_el, spike_snapshot=[0.5, 1.0],


### PR DESCRIPTION
- Removed unused filter function from `blech_process_utils.py`.
- Relocated `get_filtered_electrode` function from `clustering.py` to `read_file.py` for better organization.
- Commented out redundant filter call in `blech_process_utils.py`.
- Updated `read_file.py` to include filtering logic directly within its data processing. 
