### PR TITLE
551 perform frequency filtering when loading data in blech clustpy rather than in blech processpy

### DIFF
--- a/blech_process.py
+++ b/blech_process.py
@@ -31,6 +31,7 @@ import time
 import argparse  # noqa
 import os  # noqa
 from utils.blech_utils import imp_metadata, pipeline_graph_check  # noqa
+import utils.read_file as read_file
 
 test_bool = False
 if test_bool:

--- a/blech_process.py
+++ b/blech_process.py
@@ -137,8 +137,8 @@ electrode = bpu.electrode_handler(
     electrode_num,
     params_dict)
 
-# Run complete preprocessing pipeline
-filtered_data = electrode.preprocess_electrode()
+# Apply frequency filtering
+filtered_data = read_file.filter_electrode(electrode.raw_el, params_dict)
 
 #############################################################
 # Process Spikes

--- a/utils/blech_process_utils.py
+++ b/utils/blech_process_utils.py
@@ -948,11 +948,6 @@ class electrode_handler():
 
     def filter_electrode(self):
         # Raw units get multiplied by 0.195 to get MICROVOLTS
-        self.filt_el = clust.get_filtered_electrode(
-            self.raw_el,
-            freq=[self.params_dict['bandpass_lower_cutoff'],
-                  self.params_dict['bandpass_upper_cutoff']],
-            sampling_rate=self.params_dict['sampling_rate'],)
         # Delete raw electrode recording from memory
         del self.raw_el
 

--- a/utils/read_file.py
+++ b/utils/read_file.py
@@ -27,6 +27,7 @@ import pandas as pd
 # https://github.com/Intan-Technologies/load-rhd-notebook-python
 
 from utils.importrhdutilities import load_file, read_header
+import utils.clustering as clust
 
 
 class DigInHandler:

--- a/utils/read_file.py
+++ b/utils/read_file.py
@@ -386,3 +386,19 @@ def read_electrode_emg_channels_single_file(
             exec(
                 f"hf5.root.raw_emg.emg{channel_ind:02}.append(amp_reshape[num,:])")
     hf5.close()
+def filter_electrode(raw_el, params_dict):
+    """
+    Apply frequency filtering to electrode data.
+
+    Args:
+        raw_el: Raw electrode data.
+        params_dict: Dictionary containing filter parameters.
+
+    Returns:
+        Filtered electrode data.
+    """
+    return clust.get_filtered_electrode(
+        raw_el,
+        freq=[params_dict['bandpass_lower_cutoff'],
+              params_dict['bandpass_upper_cutoff']],
+        sampling_rate=params_dict['sampling_rate'])


### PR DESCRIPTION
- **feat: move frequency filtering functionality to read_file.py**
- **fix: import missing modules to resolve undefined name errors**
