### PR TITLE
Move test data to ~/.blech_clust_test_data

### DIFF
--- a/pipeline_testing/README.md
+++ b/pipeline_testing/README.md
@@ -12,9 +12,11 @@ The testing framework allows automated testing of different components of the bl
 
 ## Test Data
 
-The framework uses small test datasets that can be automatically downloaded:
+The framework uses small test datasets that can be automatically downloaded to `~/.blech_clust_test_data`:
 - OFPC format data: `KM45_5tastes_210620_113227_new`
 - Traditional format data: `eb24_behandephys_11_12_24_241112_114659_copy`
+
+Test data is stored outside the repository directory to allow clean repo cloning without re-downloading data.
 
 ## Running Tests
 

--- a/pipeline_testing/prefect_pipeline.py
+++ b/pipeline_testing/prefect_pipeline.py
@@ -141,14 +141,12 @@ with open(emg_params_path) as f:
     env_params = json.load(f)
 emg_env_path = env_params['emg_env']
 
-# data_subdir = 'pipeline_testing/test_data_handling/test_data/KM45_5tastes_210620_113227_new'
-# data_subdir = 'pipeline_testing/test_data_handling/eb24_behandephys_11_12_24_241112_114659_copy'
+# Use home directory for test data to allow clean repo cloning
 data_subdirs_dict = {
     'ofpc': 'KM45_5tastes_210620_113227_new',
     'trad': 'eb24_behandephys_11_12_24_241112_114659_copy'
 }
-data_dir_base = os.path.join(
-    blech_clust_dir, 'pipeline_testing', 'test_data_handling', 'test_data')
+data_dir_base = os.path.expanduser('~/.blech_clust_test_data')
 data_dirs_dict = {key: os.path.join(data_dir_base, subdir)
                   for key, subdir in data_subdirs_dict.items()}
 

--- a/pipeline_testing/test_data_handling/download_test_data.sh
+++ b/pipeline_testing/test_data_handling/download_test_data.sh
@@ -15,10 +15,11 @@ DATA_DIR_NAMES=(
     eb24_behandephys_11_12_24_241112_114659_copy
 )
 
-DATA_SUP_DIR=${DIR_PATH}/test_data
+# Use home directory for test data to allow clean repo cloning
+DATA_SUP_DIR=~/.blech_clust_test_data
 # If DATA_DIR does not exist, create it
 if [ ! -d "$DATA_SUP_DIR" ]; then
-    mkdir $DATA_SUP_DIR
+    mkdir -p $DATA_SUP_DIR
 fi
 
 for i in {0..1}


### PR DESCRIPTION
Fixes #605

This PR moves pipeline testing data from within the repository to ~/.blech_clust_test_data in the user's home directory.

Changes:
- download_test_data.sh: Updated DATA_SUP_DIR to use ~/.blech_clust_test_data
- prefect_pipeline.py: Updated data_dir_base to use os.path.expanduser
- README.md: Documented the new test data location

Benefits:
- Allows wiping out the blech_clust directory and recloning on the runner without re-downloading test data
- Ensures clean code every time while preserving test datasets
- Separates code from data, following best practices