### PR TITLE
Extract recording parameters from info.rhd and include in .info file

### DIFF
--- a/blech_exp_info.py
+++ b/blech_exp_info.py
@@ -334,7 +334,7 @@ def extract_recording_params(dir_path, header=None):
     if header is not None:
         try:
             freq_params = header.get('frequency_parameters', {})
-            
+
             recording_params = {
                 'sampling_rate': header.get('sample_rate'),
                 'notch_filter_frequency': header.get('notch_filter_frequency'),
@@ -346,12 +346,12 @@ def extract_recording_params(dir_path, header=None):
                 'desired_lower_bandwidth': freq_params.get('desired_lower_bandwidth'),
                 'desired_upper_bandwidth': freq_params.get('desired_upper_bandwidth'),
             }
-            
+
             return recording_params
         except Exception as e:
             print(f'Error extracting recording parameters from header: {e}')
             return None
-    
+
     # Otherwise, try to read from info.rhd file
     info_rhd_path = os.path.join(dir_path, 'info.rhd')
 


### PR DESCRIPTION
## Summary
Extracts recording frequency bandwidth parameters from info.rhd files and includes them in the generated .info JSON file.

## Changes
- Added `extract_recording_params()` function to read header from info.rhd
- Extracts sampling rate, notch filter frequency, DSP settings, and bandwidth parameters
- Integrates recording parameters into the final .info dictionary
- Handles cases where info.rhd is not present gracefully

## Parameters Extracted
- sampling_rate
- notch_filter_frequency
- dsp_enabled
- actual_dsp_cutoff_frequency
- actual_lower_bandwidth
- actual_upper_bandwidth
- desired_dsp_cutoff_frequency
- desired_lower_bandwidth
- desired_upper_bandwidth

Fixes #637