### PR TITLE
Interpolate waveforms to 30kHz for classifier compatibility

### DIFF
--- a/blech_process.py
+++ b/blech_process.py
@@ -224,7 +224,8 @@ if classifier_params['use_classifier'] and \
         classifier_params['use_neuRecommend']:
     print(' == Using neuRecommend classifier ==')
     # Interpolate waveforms to 30kHz for classifier compatibility
-    interpolated_slices = spike_set.interpolate_waveforms(target_sampling_rate=30000.0)
+    interpolated_slices = spike_set.interpolate_waveforms(
+        target_sampling_rate=30000.0)
     # Full classification pipeline also has feature transformation pipeline
     classifier_handler.classify_waveforms(
         interpolated_slices,

--- a/utils/blech_process_utils.py
+++ b/utils/blech_process_utils.py
@@ -1121,7 +1121,7 @@ class spike_handler():
     def interpolate_waveforms(self, target_sampling_rate=30000.0):
         """
         Interpolate waveforms to match expected sampling rate for classifier.
-        
+
         This allows the classifier to work with data recorded at different
         sampling rates as long as pre/post windows are the same.
         """

--- a/utils/clustering.py
+++ b/utils/clustering.py
@@ -266,15 +266,15 @@ def dejitter_abu3(slices,
     return slices_dejittered, spike_times
 
 
-def interpolate_waveforms_to_30khz(slices, spike_snapshot=[0.5, 1.0], 
-                                    actual_sampling_rate=30000.0,
-                                    target_sampling_rate=30000.0):
+def interpolate_waveforms_to_30khz(slices, spike_snapshot=[0.5, 1.0],
+                                   actual_sampling_rate=30000.0,
+                                   target_sampling_rate=30000.0):
     """
     Interpolate waveforms to match expected number of datapoints at target sampling rate.
-    
+
     Allows classifier trained on 30kHz data to work with data recorded at different
     sampling rates, as long as pre/post windows are the same.
-    
+
     Parameters
     ----------
     slices : np.ndarray
@@ -285,7 +285,7 @@ def interpolate_waveforms_to_30khz(slices, spike_snapshot=[0.5, 1.0],
         Actual sampling rate of the data in Hz
     target_sampling_rate : float
         Target sampling rate to interpolate to (typically 30000 Hz)
-        
+
     Returns
     -------
     interpolated_slices : np.ndarray
@@ -293,21 +293,22 @@ def interpolate_waveforms_to_30khz(slices, spike_snapshot=[0.5, 1.0],
     """
     if actual_sampling_rate == target_sampling_rate:
         return slices
-    
+
     # Calculate expected number of samples at each rate
     total_window_ms = spike_snapshot[0] + spike_snapshot[1]
     actual_n_samples = slices.shape[1]
     target_n_samples = int((total_window_ms / 1000.0) * target_sampling_rate)
-    
+
     # Create interpolation function for each waveform
     x_actual = np.linspace(0, total_window_ms, actual_n_samples)
     x_target = np.linspace(0, total_window_ms, target_n_samples)
-    
+
     interpolated_slices = np.zeros((slices.shape[0], target_n_samples))
     for i, waveform in enumerate(slices):
-        f = interp1d(x_actual, waveform, kind='cubic', fill_value='extrapolate')
+        f = interp1d(x_actual, waveform, kind='cubic',
+                     fill_value='extrapolate')
         interpolated_slices[i] = f(x_target)
-    
+
     return interpolated_slices
 
 


### PR DESCRIPTION
Fixes #193

This PR adds waveform interpolation to enable the classifier to work with data recorded at different sampling rates, as long as the pre and post spike windows are the same.

## Changes

- **Added `interpolate_waveforms_to_30khz()` function** in `utils/clustering.py`: Interpolates waveforms from any sampling rate to match the expected 30kHz sampling rate using cubic interpolation
- **Added `interpolate_waveforms()` method** to `spike_handler` class in `utils/blech_process_utils.py`: Wrapper method that uses the spike snapshot parameters and actual sampling rate from the data
- **Updated `blech_process.py`**: Interpolates waveforms before passing them to the classifier

## How it works

When data is recorded at a different sampling rate (e.g., 20kHz), the same time window (e.g., 0.5ms pre + 1.0ms post) will contain a different number of samples than at 30kHz. The interpolation function:

1. Calculates the expected number of samples at both the actual and target sampling rates
2. Creates time vectors for both sampling rates
3. Uses cubic interpolation to resample each waveform to the target number of samples
4. Returns waveforms with the same shape as if they were recorded at 30kHz

This allows the classifier, which was trained on 30kHz data, to work correctly with data from any sampling rate.
