### PR TITLE
remove progress from blech_units_characteristics.py

### DIFF
--- a/blech_units_characteristics.py
+++ b/blech_units_characteristics.py
@@ -578,6 +578,7 @@ def palatability_corr(x):
     rho, p = spearmanr(x.firing, x.pal_rank)
     return pd.Series({'rho': rho, 'pval': p})
 
+
 pal_frame = seq_firing_frame.groupby(group_cols).apply(palatability_corr)
 pal_frame.reset_index(inplace=True)
 pal_frame['abs_rho'] = pal_frame.rho.abs()


### PR DESCRIPTION
Reverting progress_apply to just apply fixes a compatability issue between the old versions of TQDM and pandas