### PR TITLE
Update GitHub workflow using conda run to pass through output similar to makefile

### DIFF
--- a/.github/workflows/installation_test.yml
+++ b/.github/workflows/installation_test.yml
@@ -110,11 +110,11 @@ jobs:
 
       - name: Verify installation
         run: |
-          conda run -n blech_clust python -c "import numpy; print('NumPy version:', numpy.__version__)"
-          conda run -n blech_clust python -c "import scipy; print('SciPy version:', scipy.__version__)"
-          conda run -n blech_clust python -c "import matplotlib; print('Matplotlib version:', matplotlib.__version__)"
-          conda run -n blech_clust python -c "import sklearn; print('Scikit-learn version:', sklearn.__version__)"
-          conda run -n blech_clust python -c "import blech_clust; print('blech_clust package installed successfully')"
+          conda run --no-capture-output -n blech_clust python -c "import numpy; print('NumPy version:', numpy.__version__)"
+          conda run --no-capture-output -n blech_clust python -c "import scipy; print('SciPy version:', scipy.__version__)"
+          conda run --no-capture-output -n blech_clust python -c "import matplotlib; print('Matplotlib version:', matplotlib.__version__)"
+          conda run --no-capture-output -n blech_clust python -c "import sklearn; print('Scikit-learn version:', sklearn.__version__)"
+          conda run --no-capture-output -n blech_clust python -c "import blech_clust; print('blech_clust package installed successfully')"
 
       - name: Test basic functionality
         run: |

--- a/.github/workflows/pytest_workflow.yml
+++ b/.github/workflows/pytest_workflow.yml
@@ -37,11 +37,11 @@ jobs:
 
       - name: Run pytest
         run: |
-          conda run -n blech_clust python -m pytest tests/ -v
+          conda run --no-capture-output -n blech_clust python -m pytest tests/ -v
 
       - name: Run pytest with coverage
         run: |
-          conda run -n blech_clust python -m pytest tests/ --cov=. --cov-report=xml
+          conda run --no-capture-output -n blech_clust python -m pytest tests/ --cov=. --cov-report=xml
 
       - name: Cleanup after tests
         if: always()

--- a/.github/workflows/python_workflow_test.yml
+++ b/.github/workflows/python_workflow_test.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Prefect SPIKE then EMG test
         shell: bash
         working-directory: /home/exouser/Desktop/blech_clust
-        run: conda run -n blech_clust python pipeline_testing/prefect_pipeline.py --spike-emg 2>&1 |
+        run: conda run --no-capture-output -n blech_clust python pipeline_testing/prefect_pipeline.py --spike-emg 2>&1 |
               tee ~/Desktop/blech_clust/github.log;
               if grep -q "ERROR" ~/Desktop/blech_clust/github.log; then
                 echo "ERROR detected by bash";
@@ -94,7 +94,7 @@ jobs:
       - name: Prefect EMG only test
         shell: bash
         working-directory: /home/exouser/Desktop/blech_clust
-        run: conda run -n blech_clust python pipeline_testing/prefect_pipeline.py -e 2>&1 |
+        run: conda run --no-capture-output -n blech_clust python pipeline_testing/prefect_pipeline.py -e 2>&1 |
               tee ~/Desktop/blech_clust/github.log;
               if grep -q "ERROR" ~/Desktop/blech_clust/github.log; then
                 echo "ERROR detected by bash";


### PR DESCRIPTION
## Summary
This PR addresses issue #691 by updating all GitHub workflows to use the `--no-capture-output` flag with `conda run` commands, ensuring that output is passed through similar to the behavior in the Makefile.

## Changes Made
- **pytest_workflow.yml**: Added `--no-capture-output` flag to both pytest commands
- **installation_test.yml**: Added `--no-capture-output` flag to all verification commands
- **python_workflow_test.yml**: Added `--no-capture-output` flag to both pipeline test commands

## Technical Details
The Makefile already uses `--no-capture-output` with all `conda run` commands to ensure proper output streaming. However, the GitHub workflows were missing this flag, which could result in output being buffered or not properly displayed in the workflow logs.

## Testing
- All workflow files have been updated consistently
- The changes follow the same pattern already established in the Makefile
- No functional changes to the workflow logic, only improved output handling

## Impact
This change ensures that:
- Workflow logs will show real-time output from conda commands
- Debugging will be easier with immediate visibility of command output
- Consistency between local development (Makefile) and CI/CD (GitHub Actions) behavior

Fixes #691

@abuzarmahmood can click here to [continue refining the PR](https://app.all-hands.dev/conversations/d17d7f1d6fc544078401728578bdc397)