### PR TITLE
Add taste delivery day field to experiment info

### DIFF
--- a/blech_exp_info.py
+++ b/blech_exp_info.py
@@ -422,7 +422,8 @@ def display_existing_info(existing_info):
         print(f"Tastes: {taste_params.get('tastes', [])}")
         print(f"Concentrations: {taste_params.get('concs', [])}")
         print(f"Palatability rankings: {taste_params.get('pal_rankings', [])}")
-        print(f"Taste delivery day: {taste_params.get('taste_delivery_day', 'Not set')}")
+        print(
+            f"Taste delivery day: {taste_params.get('taste_delivery_day', 'Not set')}")
 
     if 'laser_params' in existing_info:
         laser_params = existing_info['laser_params']
@@ -463,7 +464,8 @@ def process_dig_ins_programmatic(this_dig_handler, args):
     if args.taste_delivery_day is not None:
         taste_delivery_day = args.taste_delivery_day
     else:
-        raise ValueError('Taste delivery day not provided, use --taste-delivery-day')
+        raise ValueError(
+            'Taste delivery day not provided, use --taste-delivery-day')
 
     # Process taste dig-ins
     if args.taste_digins:
@@ -708,7 +710,8 @@ def process_dig_ins_manual(this_dig_handler, args, existing_info, cache, cache_f
         force_default=args.auto_defaults
     )
 
-    taste_delivery_day = int(taste_delivery_day_str) if taste_delivery_day_str and taste_delivery_day_str.strip() else None
+    taste_delivery_day = int(
+        taste_delivery_day_str) if taste_delivery_day_str and taste_delivery_day_str.strip() else None
 
     if 'taste_params' not in cache:
         cache['taste_params'] = {}

--- a/tests/test_blech_exp_info.py
+++ b/tests/test_blech_exp_info.py
@@ -59,13 +59,13 @@ class TestBlechExpInfo:
         mock_dig_handler.dig_in_frame.trial_counts = [10, 15, 12, 8]
         mock_dig_handler.dig_in_frame.loc = MagicMock()
         mock_dig_handler.dig_in_frame.dig_in_nums = [1, 2, 3, 4]
-        
+
         # Mock the get_dig_in_files and get_trial_data methods
         mock_dig_handler.get_dig_in_files = MagicMock()
         mock_dig_handler.get_trial_data = MagicMock()
 
         result = process_dig_ins_programmatic(mock_dig_handler, mock_args)
-        
+
         # Check that taste_delivery_day is included in the result
         assert len(result) == 7  # Should have 7 elements now
         taste_dig_inds, tastes, concs, pal_ranks, taste_digin_nums, taste_digin_trials, taste_delivery_day = result
@@ -105,10 +105,11 @@ class TestBlechExpInfo:
 
         with patch('builtins.print') as mock_print:
             display_existing_info(existing_info)
-            
+
             # Check that taste delivery day was printed
             print_calls = [str(call) for call in mock_print.call_args_list]
-            taste_delivery_day_found = any('Taste delivery day: 3' in call for call in print_calls)
+            taste_delivery_day_found = any(
+                'Taste delivery day: 3' in call for call in print_calls)
             assert taste_delivery_day_found
 
     def test_display_existing_info_handles_missing_taste_delivery_day(self):
@@ -125,10 +126,11 @@ class TestBlechExpInfo:
 
         with patch('builtins.print') as mock_print:
             display_existing_info(existing_info)
-            
+
             # Check that "Not set" was printed for taste delivery day
             print_calls = [str(call) for call in mock_print.call_args_list]
-            taste_delivery_day_found = any('Taste delivery day: Not set' in call for call in print_calls)
+            taste_delivery_day_found = any(
+                'Taste delivery day: Not set' in call for call in print_calls)
             assert taste_delivery_day_found
 
     @patch('blech_clust.blech_exp_info.setup_experiment_info')
@@ -143,17 +145,18 @@ class TestBlechExpInfo:
     @patch('os.path.exists')
     @patch('os.listdir')
     def test_main_includes_taste_delivery_day_in_final_dict(self, mock_listdir, mock_exists, mock_json_dump,
-                                                           mock_extract_recording, mock_process_notes,
-                                                           mock_process_layout, mock_process_electrodes,
-                                                           mock_process_laser, mock_process_taste,
-                                                           mock_dig_handler, mock_setup):
+                                                            mock_extract_recording, mock_process_notes,
+                                                            mock_process_layout, mock_process_electrodes,
+                                                            mock_process_laser, mock_process_taste,
+                                                            mock_dig_handler, mock_setup):
         """Test that main function includes taste delivery day in final dictionary."""
-        
+
         # Setup mocks
-        mock_setup.return_value = ('/test/path', 'test_dir', '/cache/path', {}, {}, {}, None)
+        mock_setup.return_value = (
+            '/test/path', 'test_dir', '/cache/path', {}, {}, {}, None)
         mock_listdir.return_value = ['auxiliary.dat']
         mock_exists.return_value = True
-        
+
         # Mock dig handler
         mock_handler_instance = MagicMock()
         mock_dig_handler.return_value = mock_handler_instance
@@ -161,26 +164,27 @@ class TestBlechExpInfo:
         mock_handler_instance.dig_in_frame.dig_in_nums = [1, 2, 3, 4]
         mock_handler_instance.dig_in_frame.trial_counts = [10, 15, 12, 8]
         mock_handler_instance.write_out_frame = MagicMock()
-        
+
         # Mock taste processing to return taste_delivery_day
-        mock_process_taste.return_value = ([1, 2, 3, 4], ['NaCl', 'Quinine', 'Sucrose', 'Citric'], 
-                                          [0.1, 0.001, 0.3, 0.01], [1, 2, 4, 3], 
-                                          [1, 2, 3, 4], [10, 15, 12, 8], 2)
-        
+        mock_process_taste.return_value = ([1, 2, 3, 4], ['NaCl', 'Quinine', 'Sucrose', 'Citric'],
+                                           [0.1, 0.001, 0.3, 0.01], [
+                                               1, 2, 4, 3],
+                                           [1, 2, 3, 4], [10, 15, 12, 8], 2)
+
         # Mock other processes
         mock_process_laser.return_value = (None, [], [], '', [])
         mock_process_electrodes.return_value = ([], [], [])
         mock_process_layout.return_value = ({}, None, [], '')
         mock_process_notes.return_value = 'Test notes'
         mock_extract_recording.return_value = None
-        
+
         # Mock args for programmatic mode
         with patch('blech_clust.blech_exp_info.args') as mock_args:
             mock_args.programmatic = True
             mock_args.template = None
-            
+
             result = main()
-            
+
             # Check that taste_delivery_day is in the final dictionary
             assert 'taste_params' in result
             assert 'taste_delivery_day' in result['taste_params']
@@ -209,15 +213,16 @@ class TestBlechExpInfo:
         with patch('blech_clust.blech_exp_info.populate_field_with_defaults') as mock_populate:
             # Mock the populate_field_with_defaults to return taste delivery day
             mock_populate.return_value = '3'
-            
+
             with patch('blech_clust.blech_exp_info.save_to_cache'):
-                result = process_dig_ins_manual(mock_dig_handler, mock_args, existing_info, cache, cache_file_path)
-                
+                result = process_dig_ins_manual(
+                    mock_dig_handler, mock_args, existing_info, cache, cache_file_path)
+
                 # Check that taste_delivery_day is included in the result
                 assert len(result) == 7  # Should have 7 elements now
                 taste_dig_inds, tastes, concs, pal_ranks, taste_digin_nums, taste_digin_trials, taste_delivery_day = result
                 assert taste_delivery_day == 3
-                
+
                 # Check that cache was updated with taste delivery day
                 assert 'taste_params' in cache
                 assert 'taste_delivery_day' in cache['taste_params']


### PR DESCRIPTION
This PR addresses issue #679 by adding a taste-delivery day field to the experiment info file.

## Summary
- Added `--taste-delivery-day` command line argument to `blech_exp_info.py`
- Updated both programmatic and manual taste processing to include taste delivery day
- Added `taste_delivery_day` to the final info dictionary structure under `taste_params`
- Implemented caching support for taste delivery day in manual mode
- Updated `display_existing_info` function to show taste delivery day when displaying existing info
- Added comprehensive tests to verify the functionality

## Changes Made

### Command Line Interface
- Added `--taste-delivery-day` argument (type: int) to the argument parser
- Made it optional with proper help text explaining its purpose

### Programmatic Mode
- Updated `process_dig_ins_programmatic` to require and process taste delivery day
- Added validation to ensure taste delivery day is provided in programmatic mode
- Updated return tuple to include taste delivery day

### Manual Mode  
- Updated `process_dig_ins_manual` to prompt for taste delivery day
- Added integer validation for taste delivery day input
- Implemented caching to remember taste delivery day across sessions
- Added proper error handling and user-friendly prompts

### Data Structure
- Added `taste_delivery_day` field to the `taste_params` section of the final info dictionary
- Updated JSON serialization to include the new field

### User Experience
- Enhanced `display_existing_info` to show taste delivery day when displaying existing info
- Added "Not set" display for missing taste delivery day values

### Testing
- Created comprehensive test suite in `tests/test_blech_exp_info.py`
- Tests cover argument parsing, programmatic mode, manual mode, caching, and JSON serialization
- Verified both positive cases and error handling

## Rationale
As mentioned in issue #679, intra-session dynamics are different on different days (Svedberg, Daniel A., and Donald B. Katz. "Neural Correlates of Rapid Familiarization to Novel Taste." 9 May 2024. Neuroscience, https://doi.org/10.1101/2024.05.08.593234.), making taste delivery day an important piece of information for re-using previously recorded data. While this could potentially be inferred from a database, there's no guarantee that all sessions will be kept or easily collated, so explicitly recording this information ensures it's always available.

## Usage Examples

### Programmatic Mode
```bash
python blech_exp_info.py /path/to/data --programmatic --taste-delivery-day 2 --taste-digins "1,2,3,4" --tastes "NaCl,Quinine,Sucrose,Citric" --concentrations "0.1,0.001,0.3,0.01" --palatability "1,2,4,3"
```

### Manual Mode
```bash
python blech_exp_info.py /path/to/data
# User will be prompted: "Enter taste delivery day number (e.g., 1, 2, 3...)"
```

## Testing
The implementation has been tested with:
- Argument parsing functionality
- Programmatic mode with and without taste delivery day
- Manual mode with caching
- JSON serialization/deserialization
- Error handling for invalid inputs

Fixes #679

@abuzarmahmood can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f66c8feb74ae4c7aa05f2c0757d468b4)