### PR TITLE
Update docs/README to use mkdocs rather than quarto

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,45 +46,30 @@ We welcome improvements to our documentation! See [docs/README.md](docs/README.m
 - Building documentation locally
 - Editing existing pages
 - Adding new pages
-- Using Quarto Markdown features
+- Using MkDocs and Material theme features
 - Deployment process
 
 **Quick start for documentation:**
 
 ```bash
-# Install Quarto (if not already installed)
-# See https://quarto.org/docs/get-started/
+# Install MkDocs dependencies (if not already installed)
+pip install -r requirements/requirements-docs.txt
 
-# Navigate to docs directory
-cd docs
-
+# From the repository root
 # Preview documentation with live reload
-quarto preview
+mkdocs serve
 
-# Make your edits to .qmd files
+# Make your edits to .md files
 
 # Build the site
-quarto render
+mkdocs build
 ```
 
 **For auto-generated API docs:**
 
-```bash
-# Generate API docs from docstrings (optional)
-cd docs
-quartodoc build
-
-# Preview with generated docs
-quarto preview
-
-# Commit generated docs (use -f to override gitignore)
-git add -f docs/reference/api/*.qmd
-git commit -m "Update auto-generated API docs"
-```
+The API documentation is automatically generated using mkdocstrings from your Python docstrings when you run `mkdocs serve` or `mkdocs build`. No separate generation step is required.
 
 Documentation is automatically deployed to GitHub Pages when changes are merged to `master`.
-
-**Note:** Auto-generation is disabled in CI but works locally. If you update docstrings and want the API docs published, you must generate and commit them locally.
 
 ## Code of Conduct
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,15 +9,20 @@ docs/
 ├── index.md                 # Home page
 ├── getting-started/         # Installation and setup guides
 │   ├── installation.md
-│   └── quickstart.md
+│   ├── quickstart.md
+│   └── migration-guide/     # Migration guide for v2.0
+│       ├── index.md         # Migration overview
+│       ├── removed-features.md
+│       ├── file-mapping.md
+│       └── qa-improvements.md
 ├── tutorials.md             # Step-by-step tutorials
 ├── reference/               # API reference documentation
 │   ├── index.md            # API reference home
 │   ├── core-pipeline.md    # Core pipeline modules
 │   ├── utilities.md        # Utility modules
 │   ├── ephys-data.md       # Ephys data analysis
-│   ├── qa-tools.md         # Quality assurance tools
 │   └── emg-analysis.md     # EMG analysis
+├── workflow.md             # Workflow diagrams
 └── .gitignore              # Ignore generated files
 ```
 
@@ -78,6 +83,14 @@ This starts a local server at [http://127.0.0.1:8000](http://127.0.0.1:8000) tha
    nav:
      - Section Name:
          - Page Title: path/to/page.md
+   ```
+   For example, to add a new page to the Getting Started section:
+   ```yaml
+   nav:
+     - Getting Started:
+         - Installation: getting-started/installation.md
+         - Quick Start: getting-started/quickstart.md
+         - Your New Page: getting-started/your-page.md
    ```
 3. **Build and preview** to verify
 
@@ -147,6 +160,7 @@ def hello():
 
 ```markdown
 See the [Getting Started](getting-started/installation.md) guide.
+See the [Migration Guide](getting-started/migration-guide/index.md) for v2.0 changes.
 See the [Core Pipeline](reference/core-pipeline.md) documentation.
 ```
 


### PR DESCRIPTION
## Summary
This PR updates the documentation to properly reflect the use of MkDocs instead of Quarto, addressing issue #699.

## Changes Made
- **docs/README.md**: Updated documentation structure to match the actual mkdocs.yml configuration
  - Removed outdated `qa-tools.md` reference that doesn't exist
  - Added migration guide information that was missing
  - Updated navigation examples to reflect actual structure
  - Added workflow.md to the structure documentation

- **CONTRIBUTING.md**: Replaced all Quarto-related instructions with MkDocs equivalents
  - Updated quick start documentation commands
  - Replaced `quarto preview` with `mkdocs serve`
  - Replaced `quarto render` with `mkdocs build`
  - Updated API documentation instructions to use mkdocstrings instead of quartodoc
  - Removed manual API generation steps since mkdocstrings handles this automatically

## Verification
- Documentation structure now matches mkdocs.yml configuration
- All references to Quarto have been replaced with MkDocs equivalents
- API documentation generation instructions are now accurate for mkdocstrings
- Requirements file already contains correct MkDocs dependencies

## Testing
The changes can be verified by:
1. Running `mkdocs serve` from the repository root
2. Checking that the documentation builds without errors
3. Verifying the navigation structure matches the updated documentation

Fixes #699

@abuzarmahmood can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f4760e43656a4684b0b2a09e61478ee5)