### PR TITLE
Add CAR correlation comparison plots for QA validation

### DIFF
--- a/blech_common_avg_reference.py
+++ b/blech_common_avg_reference.py
@@ -391,17 +391,21 @@ def plot_clustered_corr_mat(
     fig_height = max(8, n_chans * 0.15)
     fontsize = max(4, 8 - n_chans // 20)
 
-    # Plot clustered correlation matrix
+    # Plot clustered correlation matrix with shared colorbar
     fig, ax = plt.subplots(1, 3, figsize=(fig_width, fig_height),
-                           # gridspec_kw={'width_ratios': [1, 1, 0.1]}
+                           gridspec_kw={'width_ratios': [
+                               1, 1, 1], 'wspace': 0.3}
                            )
-    ax[0].imshow(corr_matrix, cmap=cmap)
+
+    # Create images for correlation matrices
+    im0 = ax[0].imshow(corr_matrix, cmap=cmap, vmin=0, vmax=1)
     ax[0].set_title('Original Correlation Matrix')
     ax[0].set_xticks(np.arange(len(electrode_names)))
     ax[0].set_yticks(np.arange(len(electrode_names)))
     ax[0].set_xticklabels(electrode_names, rotation=90, fontsize=fontsize)
     ax[0].set_yticklabels(electrode_names, fontsize=fontsize)
-    ax[1].imshow(sorted_corr_matrix, cmap=cmap)
+
+    im1 = ax[1].imshow(sorted_corr_matrix, cmap=cmap, vmin=0, vmax=1)
     ax[1].set_title('Clustered Correlation Matrix')
     ax[1].set_xticks(np.arange(len(sorted_names)))
     ax[1].set_yticks(np.arange(len(sorted_names)))
@@ -429,7 +433,13 @@ def plot_clustered_corr_mat(
             this_ax.axvline(x=i+0.5, color='black', linewidth=0.5)
             this_ax.axhline(y=i+0.5, color='black', linewidth=0.5)
 
-    plt.tight_layout()
+    # Add shared colorbar for the correlation matrices below all subplots
+    fig.subplots_adjust(bottom=0.15)  # Make room for colorbar
+    # [left, bottom, width, height]
+    cbar_ax = fig.add_axes([0.15, 0.05, 0.7, 0.03])
+    fig.colorbar(im0, cax=cbar_ax, orientation='horizontal',
+                 label='Correlation Coefficient')
+
     plt.savefig(plot_path, bbox_inches='tight', dpi=150)
     plt.close()
 

--- a/utils/qa_utils/channel_corr.py
+++ b/utils/qa_utils/channel_corr.py
@@ -114,9 +114,12 @@ def gen_corr_output(corr_mat, plot_dir, threshold=0.9, chan_labels=None):
 
     # Adjust figure size based on number of channels for readability
     n_chans = corr_mat.shape[0]
-    fig_width = max(12, n_chans * 0.2)
+    fig_width = max(18, n_chans * 0.3)
     fig_height = max(6, n_chans * 0.1)
-    fig, ax = plt.subplots(1, 2, figsize=(fig_width, fig_height))
+
+    # Add third subplot for CAR groups if labels are provided
+    n_cols = 3 if chan_labels is not None else 2
+    fig, ax = plt.subplots(1, n_cols, figsize=(fig_width, fig_height))
 
     im = ax[0].imshow(corr_mat, cmap='jet', vmin=0, vmax=1)
     ax[0].set_title('Raw Correlation Matrix')
@@ -134,12 +137,47 @@ def gen_corr_output(corr_mat, plot_dir, threshold=0.9, chan_labels=None):
 
     # Add channel labels with CAR group names if provided
     if chan_labels is not None:
-        for a in ax:
+        for a in ax[:2]:
             a.set_xticks(range(len(chan_labels)))
             a.set_yticks(range(len(chan_labels)))
             a.set_xticklabels(chan_labels, rotation=90,
                               fontsize=max(4, 8 - n_chans // 20))
             a.set_yticklabels(chan_labels, fontsize=max(4, 8 - n_chans // 20))
+
+        # Create CAR group assignment subplot
+        # Extract CAR group from labels (format: "GROUP:channel_num")
+        car_groups = []
+        for label in chan_labels:
+            if ':' in label:
+                car_groups.append(label.split(':')[0])
+            else:
+                car_groups.append('unknown')
+
+        # Map CAR groups to numeric values
+        unique_groups = list(dict.fromkeys(car_groups))  # Preserve order
+        group_map = {g: i for i, g in enumerate(unique_groups)}
+        group_nums = np.array([group_map[g] for g in car_groups])
+
+        # Create group matrix similar to cluster matrix in plot_clustered_corr_mat
+        group_matrix = np.expand_dims(
+            group_nums + 1, axis=1) == np.expand_dims(group_nums + 1, axis=0)
+        group_matrix = group_matrix * np.expand_dims(group_nums + 1, axis=1)
+
+        ax[2].imshow(group_matrix, cmap='tab10')
+        ax[2].set_title('CAR Group Assignments')
+        ax[2].set_xlabel('Channel')
+        ax[2].set_ylabel('Channel')
+        ax[2].set_xticks(range(len(chan_labels)))
+        ax[2].set_yticks(range(len(chan_labels)))
+        ax[2].set_xticklabels(chan_labels, rotation=90,
+                              fontsize=max(4, 8 - n_chans // 20))
+        ax[2].set_yticklabels(chan_labels, fontsize=max(4, 8 - n_chans // 20))
+
+        # Add dividing lines between CAR groups
+        line_locs = np.where(np.abs(np.diff(group_nums)))[0]
+        for i in line_locs:
+            ax[2].axvline(x=i+0.5, color='black', linewidth=0.5)
+            ax[2].axhline(y=i+0.5, color='black', linewidth=0.5)
 
     fig.tight_layout()
     fig.savefig(save_path, dpi=150)


### PR DESCRIPTION
## Summary

Adds channel correlation comparison plots before and after Common Average Reference (CAR) as a confirmation metric for CAR effectiveness.

## Changes

- Calculate channel correlations after CAR is applied
- Generate comparison plots saved to `QA_output/`:
  - `car_correlation_heatmaps.png`: Side-by-side heatmaps showing correlation matrices before CAR, after CAR, and the difference
  - `car_correlation_paired_plot.png`: Paired points plot showing correlation changes per channel pair with connecting lines, plus histogram of correlation changes
- Save post-CAR correlation matrix to `channel_corr_mat_post_car.nc`
- Print summary statistics showing mean correlation change and percentage of pairs with decreased correlation

## Outputs

The plots provide visual confirmation that CAR is working as expected - correlations should decrease significantly after CAR application.

**Heatmaps plot includes:**
- Before CAR correlation matrix
- After CAR correlation matrix  
- Difference matrix (Before - After) with diverging colormap

**Paired plot includes:**
- Paired points with connecting lines showing individual channel pair changes
- Mean correlation lines for before/after
- Histogram of correlation changes with statistics

Closes #727