### PR TITLE
Fix filename in nomnoml schema - change blech_unit_characteristics to blech_units_characteristics

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ Spike Sorting
 [blech_post_process] -> [blech_units_plot]
 [blech_units_plot] -> [blech_make_arrays]
 [blech_make_arrays] -> [bash blech_run_QA.sh]
-[bash blech_run_QA.sh] -> [blech_unit_characteristics]
-[blech_unit_characteristics] -> [blech_data_summary]
+[bash blech_run_QA.sh] -> [blech_units_characteristics]
+[blech_units_characteristics] -> [blech_data_summary]
 [blech_data_summary] -> [grade_dataset]
 
 EMG shared


### PR DESCRIPTION
## Summary
This PR fixes a typo in the nomnoml schema in the README.md file where `blech_unit_characteristics` was missing the "s" at the end.

## Changes Made
- Updated line 85: `[bash blech_run_QA.sh] -> [blech_unit_characteristics]` to `[bash blech_run_QA.sh] -> [blech_units_characteristics]`
- Updated line 86: `[blech_unit_characteristics] -> [blech_data_summary]` to `[blech_units_characteristics] -> [blech_data_summary]`

## Verification
- Confirmed the actual filename is `blech_units_characteristics.py` (with "s")
- Verified the detailed pipeline steps section already had the correct filename
- The nomnoml schema now matches the actual filename and the detailed pipeline description

## Issue Resolution
This fix resolves issue #745: "Pipeline diagram says unit characteristics instead of units characteristics"

## Testing
This is a documentation-only change that fixes a filename reference. No code tests are required as this only affects the nomnoml schema diagram in the README.

@abuzarmahmood can click here to [continue refining the PR](https://app.all-hands.dev/conversations/76b54cb917aa4db1a2d6a546a7948c8a)