### PR TITLE
Convert dig_in_frame.csv to long format for early dig-in timing inspection

### DIFF
--- a/blech_init.py
+++ b/blech_init.py
@@ -48,7 +48,6 @@ from blech_clust.utils.qa_utils import channel_corr  # noqa
 from blech_clust.utils import read_file  # noqa
 from blech_clust.utils.blech_channel_profile import plot_channels  # noqa
 # Necessary python modules
-from ast import literal_eval  # noqa
 import pylab as plt  # noqa
 import shutil  # noqa
 import pandas as pd  # noqa
@@ -299,7 +298,7 @@ this_dig_handler = read_file.DigInHandler(dir_name, file_type)
 this_dig_handler.load_dig_in_frame()
 
 print('DigIn data loaded')
-print(this_dig_handler.dig_in_frame.drop(columns='pulse_times'))
+print(this_dig_handler.dig_in_frame)
 
 if file_type != 'traditional':
     electrodes_list = file_lists[file_type]['electrodes']
@@ -448,12 +447,9 @@ if file_type in ['one file per channel', 'one file per signal type']:
 ##############################
 # Also output a plot with digin and laser info
 
-# Downsample to 10 seconds
-dig_in_pulses = this_dig_handler.dig_in_frame.pulse_times.values
-dig_in_pulses = [literal_eval(x) for x in dig_in_pulses]
-# Take starts of pulses
-dig_in_pulses = [[x[0] for x in this_dig] for this_dig in dig_in_pulses]
-dig_in_markers = [np.array(x) / sampling_rate for x in dig_in_pulses]
+# Build dig-in markers from long-format frame
+dig_in_frame = this_dig_handler.dig_in_frame
+dig_in_nums_unique = sorted(dig_in_frame['dig_in_nums'].unique())
 
 # Check if laser is present
 laser_dig_in = info_dict['laser_params']['dig_in_nums']
@@ -468,14 +464,17 @@ for num in laser_dig_in:
 dig_in_map = {num: dig_in_map[num] for num in sorted(list(dig_in_map.keys()))}
 dig_in_str = [f'{num}: {dig_in_map[num]}' for num in dig_in_map.keys()]
 
-for i, vals in enumerate(dig_in_markers):
-    plt.scatter(vals,
-                np.ones_like(vals)*i,
+for i, num in enumerate(dig_in_nums_unique):
+    starts = dig_in_frame.loc[dig_in_frame['dig_in_nums'] == num, 'start'].values
+    markers = np.array(starts, dtype=float) / sampling_rate
+    plt.scatter(markers,
+                np.ones_like(markers)*i,
                 s=50, marker='|', c='k')
 # If there is a laser_dig_in, mark laser trials with axvline
 if len(laser_dig_in) > 0:
-    # laser_markers = np.where(dig_in_markers[0] == laser_dig_in)[0]
-    laser_markers = dig_in_markers[laser_dig_in[0]]
+    laser_starts = dig_in_frame.loc[
+        dig_in_frame['dig_in_nums'] == laser_dig_in[0], 'start'].values
+    laser_markers = np.array(laser_starts, dtype=float) / sampling_rate
     for marker in laser_markers:
         plt.axvline(marker, c='yellow', lw=2, alpha=0.5,
                     zorder=-1)
@@ -486,34 +485,6 @@ plt.ylabel('Digital Input Channel')
 plt.savefig(os.path.join(qa_out_path, 'digital_inputs.png'))
 plt.close()
 
-##############################
-
-##############################
-# Generate long-format CSV of dig-in timings for early debugging
-# This provides trial-level timing info without requiring blech_make_arrays
-dig_in_timing_rows = []
-for _, row in this_dig_handler.dig_in_frame.iterrows():
-    dig_num = row['dig_in_nums']
-    dig_name = dig_in_map.get(dig_num, row.get('dig_in_names', ''))
-    pulse_times = row['pulse_times']
-    if isinstance(pulse_times, str):
-        pulse_times = literal_eval(pulse_times)
-    for start, end in pulse_times:
-        start_ms = (start / sampling_rate) * 1000 if start is not None else None
-        end_ms = (end / sampling_rate) * 1000 if end is not None else None
-        dig_in_timing_rows.append({
-            'dig_in_num': dig_num,
-            'dig_in_name': dig_name,
-            'start': start,
-            'end': end,
-            'start_ms': start_ms,
-            'end_ms': end_ms,
-        })
-
-dig_in_timing_frame = pd.DataFrame(dig_in_timing_rows)
-dig_in_timing_csv_path = os.path.join(dir_name, 'dig_in_timings.csv')
-dig_in_timing_frame.to_csv(dig_in_timing_csv_path, index=False)
-print(f'Dig-in timings written to {dig_in_timing_csv_path}')
 ##############################
 
 # Generate the processing scripts

--- a/blech_make_arrays.py
+++ b/blech_make_arrays.py
@@ -23,7 +23,6 @@ from blech_clust.utils.clustering import get_filtered_electrode
 from blech_clust.utils.blech_process_utils import return_cutoff_values
 from blech_clust.utils.blech_utils import imp_metadata, pipeline_graph_check
 from blech_clust.utils.read_file import DigInHandler
-from ast import literal_eval
 import matplotlib.pyplot as plt
 
 # def get_dig_in_data(hf5):
@@ -163,7 +162,7 @@ if __name__ == '__main__':
     )
     this_dig_handler.load_dig_in_frame()
     print('DigIn data loaded')
-    print(this_dig_handler.dig_in_frame.drop(columns='pulse_times'))
+    print(this_dig_handler.dig_in_frame)
 
     # Pull out taste dig-ins
     taste_digin_nums = info_dict['taste_params']['dig_in_nums']
@@ -202,17 +201,14 @@ if __name__ == '__main__':
     taste_info_list = []
     for ind, num in enumerate(taste_digin_nums):
         this_dig = this_dig_handler.dig_in_frame.loc[
-            this_dig_handler.dig_in_frame['dig_in_nums'] == num]
-        pulse_times = this_dig['pulse_times'].values[0]
-        pulse_times = literal_eval(pulse_times)
-        dig_in_name = this_dig['dig_in_names'].values[0]
+            this_dig_handler.dig_in_frame['dig_in_nums'] == num].copy()
         this_frame = pd.DataFrame(
             dict(
                 dig_in_num=num,
-                dig_in_name=dig_in_name,
+                dig_in_name=this_dig['dig_in_names'].values[0],
                 taste=this_dig['taste'].values[0],
-                start=[x[0] for x in pulse_times],
-                end=[x[1] for x in pulse_times],
+                start=this_dig['start'].values,
+                end=this_dig['end'].values,
             )
         )
         taste_info_list.append(this_frame)
@@ -231,22 +227,16 @@ if __name__ == '__main__':
     taste_info_frame.sort_values(by=['start'], inplace=True)
 
     laser_info_list = []
-    # for ind, num in enumerate(laser_digin_inds):
     for ind, num in enumerate(laser_digin_nums):
         this_dig = this_dig_handler.dig_in_frame.loc[
-            this_dig_handler.dig_in_frame['dig_in_nums'] == num]
-        # pulse_times = this_dig_handler.dig_in_frame['pulse_times'][num]
-        pulse_times = this_dig['pulse_times'].values[0]
-        pulse_times = literal_eval(pulse_times)
-        # dig_in_name = this_dig_handler.dig_in_frame['dig_in_nums'][num]
-        dig_in_name = this_dig['dig_in_names'].values[0]
+            this_dig_handler.dig_in_frame['dig_in_nums'] == num].copy()
         this_frame = pd.DataFrame(
             dict(
                 dig_in_num=num,
-                dig_in_name=dig_in_name,
+                dig_in_name=this_dig['dig_in_names'].values[0],
                 laser=True,
-                start=[x[0] for x in pulse_times],
-                end=[x[1] for x in pulse_times],
+                start=this_dig['start'].values,
+                end=this_dig['end'].values,
             )
         )
         laser_info_list.append(this_frame)


### PR DESCRIPTION
Closes #749

## Motivation

`trial_info_frame` is only generated when `blech_make_arrays.py` completes successfully. When debugging dig-in timing issues, users need to see timing data earlier in the pipeline.

## Changes

Converts `dig_in_frame.csv` from wide format (one row per dig-in channel with a `pulse_times` list column) to long format (one row per trial with scalar `start`/`end` columns). This makes dig-in timings directly inspectable from the CSV without needing `blech_make_arrays.py`.

### `utils/read_file.py` — `DigInHandler`
- Added `_expand_to_long_format()` to convert the in-memory wide frame to long format, preserving all per-channel metadata columns (taste, concentration, palatability, laser_bool, etc.)
- `write_out_frame()` now writes the long-format expansion
- `load_dig_in_frame()` loads the long-format CSV directly (removed `index_col=0`)

### `blech_init.py`
- Updated dig-in plot to read `start` values from the long-format frame instead of parsing `pulse_times`
- Removed the `literal_eval` import (no longer needed)

### `blech_make_arrays.py`
- Updated taste and laser info frame construction to use `start`/`end` columns directly instead of parsing `pulse_times`
- Removed the `literal_eval` import

### Unchanged
- `blech_exp_info.py` builds the wide-format frame in memory via `get_trial_data()` and is unaffected — the long-format conversion only happens at CSV write time."