### PR TITLE
Add overwrite-dependencies flag for dependency graph checks (fixes #766)

### DIFF
--- a/blech_common_avg_reference.py
+++ b/blech_common_avg_reference.py
@@ -679,7 +679,8 @@ if not testing_bool:
     dir_name = metadata_handler.dir_name
     # Now create pipeline check with the correct dir_name
     overwrite_dependencies = args.overwrite_dependencies
-    this_pipeline_check = pipeline_graph_check(dir_name, overwrite_dependencies)
+    this_pipeline_check = pipeline_graph_check(
+        dir_name, overwrite_dependencies)
     this_pipeline_check.check_previous(script_path)
     this_pipeline_check.write_to_log(script_path, 'attempted')
 

--- a/blech_exp_info.py
+++ b/blech_exp_info.py
@@ -724,7 +724,8 @@ def setup_experiment_info():
 
     if not test_bool:
         script_path = os.path.abspath(__file__)
-        this_pipeline_check = pipeline_graph_check(dir_path, args.overwrite_dependencies)
+        this_pipeline_check = pipeline_graph_check(
+            dir_path, args.overwrite_dependencies)
         this_pipeline_check.write_to_log(script_path, 'attempted')
 
     # Set up cache

--- a/blech_init.py
+++ b/blech_init.py
@@ -202,7 +202,8 @@ if not testing_bool:
     dir_name = metadata_handler.dir_name
 
     # Now create pipeline check with the correct dir_name
-    this_pipeline_check = pipeline_graph_check(dir_name, overwrite_dependencies)
+    this_pipeline_check = pipeline_graph_check(
+        dir_name, overwrite_dependencies)
     this_pipeline_check.check_previous(script_path)
     this_pipeline_check.write_to_log(script_path, 'attempted')
     # If info_dict present but execution log is not

--- a/blech_make_arrays.py
+++ b/blech_make_arrays.py
@@ -149,7 +149,8 @@ if __name__ == '__main__':
 
         # Perform pipeline graph check
         script_path = os.path.realpath(__file__)
-        this_pipeline_check = pipeline_graph_check(metadata_handler.dir_name, overwrite_dependencies)
+        this_pipeline_check = pipeline_graph_check(
+            metadata_handler.dir_name, overwrite_dependencies)
         this_pipeline_check.check_previous(script_path)
         this_pipeline_check.write_to_log(script_path, 'attempted')
 

--- a/blech_post_process.py
+++ b/blech_post_process.py
@@ -139,7 +139,8 @@ dir_name = metadata_handler.dir_name
 
 # Perform pipeline graph check
 script_path = os.path.realpath(__file__)
-this_pipeline_check = pipeline_graph_check(dir_name, args.overwrite_dependencies)
+this_pipeline_check = pipeline_graph_check(
+    dir_name, args.overwrite_dependencies)
 this_pipeline_check.check_previous(script_path)
 this_pipeline_check.write_to_log(script_path, 'attempted')
 

--- a/blech_process.py
+++ b/blech_process.py
@@ -50,7 +50,8 @@ else:
 
     # Perform pipeline graph check
     script_path = os.path.realpath(__file__)
-    this_pipeline_check = pipeline_graph_check(args.data_dir, args.overwrite_dependencies)
+    this_pipeline_check = pipeline_graph_check(
+        args.data_dir, args.overwrite_dependencies)
     this_pipeline_check.check_previous(script_path)
     this_pipeline_check.write_to_log(script_path, 'attempted')
 

--- a/blech_units_characteristics.py
+++ b/blech_units_characteristics.py
@@ -11,6 +11,7 @@ This module performs various analyses on neural data, focusing on firing rates, 
 - **Data Export**: Merges results into a single DataFrame and exports it to CSV and HDF5 formats.
 """
 
+import argparse
 import shutil
 from tqdm import tqdm
 import pingouin as pg
@@ -39,7 +40,6 @@ tqdm.pandas()
 test_bool = False
 
 # Parse command line arguments
-import argparse
 parser = argparse.ArgumentParser(
     description='Analyze unit characteristics')
 parser.add_argument('dir_name', type=str, nargs='?',
@@ -63,7 +63,8 @@ else:
     overwrite_dependencies = args.overwrite_dependencies
     # Perform pipeline graph check
     script_path = os.path.realpath(__file__)
-    this_pipeline_check = pipeline_graph_check(dir_name, overwrite_dependencies)
+    this_pipeline_check = pipeline_graph_check(
+        dir_name, overwrite_dependencies)
     this_pipeline_check.check_previous(script_path)
     this_pipeline_check.write_to_log(script_path, 'attempted')
 

--- a/blech_units_plot.py
+++ b/blech_units_plot.py
@@ -46,7 +46,8 @@ def setup_environment(args):
 
     # Perform pipeline graph check
     script_path = os.path.realpath(__file__)
-    this_pipeline_check = pipeline_graph_check(dir_name, parsed_args.overwrite_dependencies)
+    this_pipeline_check = pipeline_graph_check(
+        dir_name, parsed_args.overwrite_dependencies)
     this_pipeline_check.check_previous(script_path)
     this_pipeline_check.write_to_log(script_path, 'attempted')
 

--- a/tests/test_pipeline_graph_check.py
+++ b/tests/test_pipeline_graph_check.py
@@ -18,84 +18,84 @@ class TestOverwriteDependenciesArgument:
         """Test that blech_init.py accepts --overwrite_dependencies argument"""
         with open('/workspace/project/blech_clust/blech_init.py', 'r') as f:
             content = f.read()
-        
+
         assert '--overwrite_dependencies' in content
 
     def test_blech_make_arrays_has_argument(self):
         """Test that blech_make_arrays.py accepts --overwrite_dependencies argument"""
         with open('/workspace/project/blech_clust/blech_make_arrays.py', 'r') as f:
             content = f.read()
-        
+
         assert '--overwrite_dependencies' in content
 
     def test_blech_process_has_argument(self):
         """Test that blech_process.py accepts --overwrite_dependencies argument"""
         with open('/workspace/project/blech_clust/blech_process.py', 'r') as f:
             content = f.read()
-        
+
         assert '--overwrite_dependencies' in content
 
     def test_blech_post_process_has_argument(self):
         """Test that blech_post_process.py accepts --overwrite_dependencies argument"""
         with open('/workspace/project/blech_clust/blech_post_process.py', 'r') as f:
             content = f.read()
-        
+
         assert '--overwrite_dependencies' in content
 
     def test_blech_common_avg_reference_has_argument(self):
         """Test that blech_common_avg_reference.py accepts --overwrite_dependencies argument"""
         with open('/workspace/project/blech_clust/blech_common_avg_reference.py', 'r') as f:
             content = f.read()
-        
+
         assert '--overwrite_dependencies' in content
 
     def test_blech_exp_info_has_argument(self):
         """Test that blech_exp_info.py accepts --overwrite_dependencies argument"""
         with open('/workspace/project/blech_clust/blech_exp_info.py', 'r') as f:
             content = f.read()
-        
+
         assert '--overwrite_dependencies' in content
 
     def test_blech_units_plot_has_argument(self):
         """Test that blech_units_plot.py accepts --overwrite_dependencies argument"""
         with open('/workspace/project/blech_clust/blech_units_plot.py', 'r') as f:
             content = f.read()
-        
+
         assert '--overwrite_dependencies' in content
 
     def test_blech_units_characteristics_has_argument(self):
         """Test that blech_units_characteristics.py accepts --overwrite_dependencies argument"""
         with open('/workspace/project/blech_clust/blech_units_characteristics.py', 'r') as f:
             content = f.read()
-        
+
         assert '--overwrite_dependencies' in content
 
     def test_utils_infer_rnn_rates_has_argument(self):
         """Test that utils/infer_rnn_rates.py accepts --overwrite_dependencies argument"""
         with open('/workspace/project/blech_clust/utils/infer_rnn_rates.py', 'r') as f:
             content = f.read()
-        
+
         assert '--overwrite_dependencies' in content
 
     def test_utils_qa_utils_drift_check_has_argument(self):
         """Test that utils/qa_utils/drift_check.py accepts --overwrite_dependencies argument"""
         with open('/workspace/project/blech_clust/utils/qa_utils/drift_check.py', 'r') as f:
             content = f.read()
-        
+
         assert '--overwrite_dependencies' in content
 
     def test_utils_qa_utils_elbo_drift_has_argument(self):
         """Test that utils/qa_utils/elbo_drift.py accepts --overwrite_dependencies argument"""
         with open('/workspace/project/blech_clust/utils/qa_utils/elbo_drift.py', 'r') as f:
             content = f.read()
-        
+
         assert '--overwrite_dependencies' in content
 
     def test_utils_qa_utils_unit_similarity_has_argument(self):
         """Test that utils/qa_utils/unit_similarity.py accepts --overwrite_dependencies argument"""
         with open('/workspace/project/blech_clust/utils/qa_utils/unit_similarity.py', 'r') as f:
             content = f.read()
-        
+
         assert '--overwrite_dependencies' in content
 
 
@@ -106,7 +106,7 @@ class TestPipelineGraphCheckClass:
         """Test that blech_utils.py pipeline_graph_check __init__ has overwrite_dependencies parameter"""
         with open('/workspace/project/blech_clust/utils/blech_utils.py', 'r') as f:
             content = f.read()
-        
+
         # Check that the __init__ method has the parameter
         assert 'def __init__(self, data_dir, overwrite_dependencies=False):' in content
         assert 'self.overwrite_dependencies = overwrite_dependencies' in content
@@ -115,7 +115,7 @@ class TestPipelineGraphCheckClass:
         """Test that check_previous method has the override logic"""
         with open('/workspace/project/blech_clust/utils/blech_utils.py', 'r') as f:
             content = f.read()
-        
+
         # Check that the check_previous method has the override logic
         assert 'if self.overwrite_dependencies:' in content
         assert "input('Continue anyway? ([y]/n) :: ')" in content

--- a/utils/blech_utils.py
+++ b/utils/blech_utils.py
@@ -229,12 +229,15 @@ class pipeline_graph_check():
                 else:
                     # Parent script not found in log
                     if self.overwrite_dependencies:
-                        print(f'WARNING: Parent script [{parent_script}] not found in log')
-                        print('Overwriting dependencies as --overwrite-dependencies flag was provided')
+                        print(
+                            f'WARNING: Parent script [{parent_script}] not found in log')
+                        print(
+                            'Overwriting dependencies as --overwrite-dependencies flag was provided')
                         return True
                     else:
                         # Ask user interactively whether to continue
-                        print(f'WARNING: Parent script [{parent_script}] not found in log')
+                        print(
+                            f'WARNING: Parent script [{parent_script}] not found in log')
                         response = input('Continue anyway? ([y]/n) :: ')
                         if response.lower() in ['', 'y', 'yes']:
                             print('Continuing with overwrite...')
@@ -246,12 +249,15 @@ class pipeline_graph_check():
             else:
                 # Log file doesn't exist
                 if self.overwrite_dependencies:
-                    print(f'WARNING: Execution log not found at {self.log_path}')
-                    print('Overwriting dependencies as --overwrite-dependencies flag was provided')
+                    print(
+                        f'WARNING: Execution log not found at {self.log_path}')
+                    print(
+                        'Overwriting dependencies as --overwrite-dependencies flag was provided')
                     return True
                 else:
                     # Ask user interactively whether to continue
-                    print(f'WARNING: Execution log not found at {self.log_path}')
+                    print(
+                        f'WARNING: Execution log not found at {self.log_path}')
                     response = input('Continue anyway? ([y]/n) :: ')
                     if response.lower() in ['', 'y', 'yes']:
                         print('Continuing with overwrite...')

--- a/utils/infer_rnn_rates.py
+++ b/utils/infer_rnn_rates.py
@@ -198,7 +198,8 @@ def parse_group_by(spikes_xr, group_by_list):
 if not test_mode:
     metadata_handler = imp_metadata([[], args.data_dir])
     # Perform pipeline graph check
-    this_pipeline_check = pipeline_graph_check(args.data_dir, args.overwrite_dependencies)
+    this_pipeline_check = pipeline_graph_check(
+        args.data_dir, args.overwrite_dependencies)
     this_pipeline_check.check_previous(script_path)
     this_pipeline_check.write_to_log(script_path, 'attempted')
 

--- a/utils/qa_utils/drift_check.py
+++ b/utils/qa_utils/drift_check.py
@@ -12,6 +12,7 @@ This module analyzes drift in firing rates across a session using statistical me
 """
 
 # Import stuff!
+import argparse
 import numpy as np
 import tables
 import sys
@@ -76,7 +77,6 @@ def array_to_df(array, dim_names):
 # Initialize
 ############################################################
 # Parse command line arguments
-import argparse
 parser = argparse.ArgumentParser(
     description='Check for drift in firing rates')
 parser.add_argument('dir_name', type=str, nargs='?',

--- a/utils/qa_utils/elbo_drift.py
+++ b/utils/qa_utils/elbo_drift.py
@@ -135,7 +135,8 @@ metadata_handler = imp_metadata([[], args.dir_name])
 dir_name = metadata_handler.dir_name
 
 # Perform pipeline graph check
-this_pipeline_check = pipeline_graph_check(dir_name, args.overwrite_dependencies)
+this_pipeline_check = pipeline_graph_check(
+    dir_name, args.overwrite_dependencies)
 this_pipeline_check.check_previous(script_path)
 this_pipeline_check.write_to_log(script_path, 'attempted')
 

--- a/utils/qa_utils/unit_similarity.py
+++ b/utils/qa_utils/unit_similarity.py
@@ -219,7 +219,8 @@ if __name__ == '__main__':
     overwrite_dependencies = args.overwrite_dependencies
 
     # Perform pipeline graph check
-    this_pipeline_check = pipeline_graph_check(dir_name, overwrite_dependencies)
+    this_pipeline_check = pipeline_graph_check(
+        dir_name, overwrite_dependencies)
     this_pipeline_check.check_previous(script_path)
     this_pipeline_check.write_to_log(script_path, 'attempted')
 


### PR DESCRIPTION
## Summary

This PR addresses issue #766 by adding an override dependency flag (`--overwrite_dependencies`) for all scripts in the pipeline that use the dependency graph check.

### Changes Made

1. **Modified `utils/blech_utils.py`**:
   - Added `overwrite_dependencies` parameter to `pipeline_graph_check.__init__()` (defaults to `False`)
   - Updated `check_previous()` method to:
     - Skip dependency check and return `True` when `overwrite_dependencies=True`
     - Ask user interactively whether to continue when check fails and `overwrite_dependencies=False`

2. **Added `--overwrite_dependencies` argument to all pipeline scripts**:
   - `blech_init.py`
   - `blech_exp_info.py`
   - `blech_common_avg_reference.py`
   - `blech_make_arrays.py`
   - `blech_process.py`
   - `blech_post_process.py`
   - `blech_units_plot.py`
   - `blech_units_characteristics.py`
   - `utils/infer_rnn_rates.py`
   - `utils/qa_utils/drift_check.py`
   - `utils/qa_utils/elbo_drift.py`
   - `utils/qa_utils/unit_similarity.py`

3. **Added tests** in `tests/test_pipeline_graph_check.py`

### Usage

Users can now:
- Use `--overwrite_dependencies` flag to bypass dependency checks entirely
- If the flag is not provided and the dependency check fails, they will be prompted interactively to continue or exit

This follows the requirements from the issue comments:
1. ✅ Add over-ride dependency flag for all scripts in pipeline
2. ✅ If flag is not supplied and dependency graph check fails, ask user interactively whether they would like to continue
