### PR TITLE
Update README to direct users to Discourse for community support

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,15 @@ Test data available at: [Google Drive](https://drive.google.com/drive/folders/1n
 
 We welcome contributions! Please read [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
+## Community and Support
+
+For general questions, discussions, and community support, please use our **[Discourse forum](https://blech-clust.discourse.diy/)**.
+
+- **Discourse**: For things other than feature requests or bugs, use the discourse forum to ask questions, share knowledge, and crowdsource solutions with other users.
+- **GitHub Issues**: For bug reports and feature requests, please open an issue on GitHub.
+
+If you're unsure whether your question belongs on Discourse or GitHub, start with Discourse! The community can help determine if a GitHub issue is warranted.
+
 ## Citation
 
 If you use this code in your research, please cite:


### PR DESCRIPTION
## Summary

This PR addresses issue #783 by updating the README to direct users to the Discourse forum for community support and discussions.

## Changes Made

- Added a new "Community and Support" section to README.md
- Included link to the Discourse forum (https://blech-clust.discourse.diy/)
- Clarified when to use Discourse vs GitHub issues

## Why This Change

As requested in the issue, users should be directed to the Discourse forum for:
- General questions not related to bugs or feature requests
- Community discussions and knowledge sharing
- Crowdsourcing solutions to issues

GitHub Issues should still be used for bug reports and feature requests.

## Testing

No tests needed for documentation changes.

## Checklist

- [x] Documentation updated
- [x] No breaking changes

---

**Related Issue**: #783