### PR TITLE
Fix issue #799: Remove dig-in loading from blech_reload_amp_digs.py

### DIFF
--- a/tests/test_blech_reload_amp_digs.py
+++ b/tests/test_blech_reload_amp_digs.py
@@ -1,0 +1,128 @@
+"""
+Test for blech_reload_amp_digs.py to ensure dig-in loading has been removed.
+
+This test verifies that the fix for issue #799 is correct - that 
+blech_reload_amp_digs.py no longer attempts to load dig-ins since they
+are now loaded into dig_in_frame via blech_init.py.
+"""
+import ast
+import os
+import pytest
+
+
+class TestBlechReloadAmpDigs:
+    """Test class for blech_reload_amp_digs module"""
+    
+    def test_no_read_digins_calls(self):
+        """Test that read_digins is not called in blech_reload_amp_digs.py"""
+        # Read the source file
+        file_path = os.path.join(
+            os.path.dirname(__file__), 
+            '..', 
+            'utils', 
+            'blech_reload_amp_digs.py'
+        )
+        
+        with open(file_path, 'r') as f:
+            source = f.read()
+        
+        # Parse the source code
+        tree = ast.parse(source)
+        
+        # Find all function calls
+        read_digins_calls = []
+        read_digins_single_file_calls = []
+        
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                if isinstance(node.func, ast.Attribute):
+                    # Check for read_file.read_digins
+                    if (isinstance(node.func.value, ast.Name) and 
+                        node.func.value.id == 'read_file' and
+                        node.func.attr == 'read_digins'):
+                        read_digins_calls.append(node.lineno)
+                    # Check for read_file.read_digins_single_file
+                    if (isinstance(node.func.value, ast.Name) and 
+                        node.func.value.id == 'read_file' and
+                        node.func.attr == 'read_digins_single_file'):
+                        read_digins_single_file_calls.append(node.lineno)
+        
+        # Assert that there are no calls to read_digins or read_digins_single_file
+        assert len(read_digins_calls) == 0, (
+            f"Found {len(read_digins_calls)} call(s) to read_digins at line(s): "
+            f"{read_digins_calls}. These should be removed as dig-ins are now "
+            f"loaded via dig_in_frame in blech_init.py"
+        )
+        
+        assert len(read_digins_single_file_calls) == 0, (
+            f"Found {len(read_digins_single_file_calls)} call(s) to "
+            f"read_digins_single_file at line(s): {read_digins_single_file_calls}. "
+            f"These should be removed as dig-ins are now loaded via "
+            f"dig_in_frame in blech_init.py"
+        )
+
+    def test_read_electrode_channels_still_present(self):
+        """Test that read_electrode_channels is still called in the file"""
+        # Read the source file
+        file_path = os.path.join(
+            os.path.dirname(__file__), 
+            '..', 
+            'utils', 
+            'blech_reload_amp_digs.py'
+        )
+        
+        with open(file_path, 'r') as f:
+            source = f.read()
+        
+        # Parse the source code
+        tree = ast.parse(source)
+        
+        # Find function calls to read_electrode_channels
+        read_electrode_channels_calls = []
+        
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                if isinstance(node.func, ast.Attribute):
+                    if (isinstance(node.func.value, ast.Name) and 
+                        node.func.value.id == 'read_file' and
+                        node.func.attr == 'read_electrode_channels'):
+                        read_electrode_channels_calls.append(node.lineno)
+        
+        # Assert that read_electrode_channels is still called
+        assert len(read_electrode_channels_calls) > 0, (
+            "read_electrode_channels should still be called in "
+            "blech_reload_amp_digs.py"
+        )
+
+    def test_read_emg_channels_still_present(self):
+        """Test that read_emg_channels is still called in the file"""
+        # Read the source file
+        file_path = os.path.join(
+            os.path.dirname(__file__), 
+            '..', 
+            'utils', 
+            'blech_reload_amp_digs.py'
+        )
+        
+        with open(file_path, 'r') as f:
+            source = f.read()
+        
+        # Parse the source code
+        tree = ast.parse(source)
+        
+        # Find function calls to read_emg_channels
+        read_emg_channels_calls = []
+        
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                if isinstance(node.func, ast.Attribute):
+                    if (isinstance(node.func.value, ast.Name) and 
+                        node.func.value.id == 'read_file' and
+                        node.func.attr == 'read_emg_channels'):
+                        read_emg_channels_calls.append(node.lineno)
+        
+        # Assert that read_emg_channels is still called
+        assert len(read_emg_channels_calls) > 0, (
+            "read_emg_channels should still be called in "
+            "blech_reload_amp_digs.py"
+        )

--- a/tests/test_blech_reload_amp_digs.py
+++ b/tests/test_blech_reload_amp_digs.py
@@ -1,7 +1,7 @@
 """
 Test for blech_reload_amp_digs.py to ensure dig-in loading has been removed.
 
-This test verifies that the fix for issue #799 is correct - that 
+This test verifies that the fix for issue #799 is correct - that
 blech_reload_amp_digs.py no longer attempts to load dig-ins since they
 are now loaded into dig_in_frame via blech_init.py.
 """
@@ -12,48 +12,48 @@ import pytest
 
 class TestBlechReloadAmpDigs:
     """Test class for blech_reload_amp_digs module"""
-    
+
     def test_no_read_digins_calls(self):
         """Test that read_digins is not called in blech_reload_amp_digs.py"""
         # Read the source file
         file_path = os.path.join(
-            os.path.dirname(__file__), 
-            '..', 
-            'utils', 
+            os.path.dirname(__file__),
+            '..',
+            'utils',
             'blech_reload_amp_digs.py'
         )
-        
+
         with open(file_path, 'r') as f:
             source = f.read()
-        
+
         # Parse the source code
         tree = ast.parse(source)
-        
+
         # Find all function calls
         read_digins_calls = []
         read_digins_single_file_calls = []
-        
+
         for node in ast.walk(tree):
             if isinstance(node, ast.Call):
                 if isinstance(node.func, ast.Attribute):
                     # Check for read_file.read_digins
-                    if (isinstance(node.func.value, ast.Name) and 
+                    if (isinstance(node.func.value, ast.Name) and
                         node.func.value.id == 'read_file' and
-                        node.func.attr == 'read_digins'):
+                            node.func.attr == 'read_digins'):
                         read_digins_calls.append(node.lineno)
                     # Check for read_file.read_digins_single_file
-                    if (isinstance(node.func.value, ast.Name) and 
+                    if (isinstance(node.func.value, ast.Name) and
                         node.func.value.id == 'read_file' and
-                        node.func.attr == 'read_digins_single_file'):
+                            node.func.attr == 'read_digins_single_file'):
                         read_digins_single_file_calls.append(node.lineno)
-        
+
         # Assert that there are no calls to read_digins or read_digins_single_file
         assert len(read_digins_calls) == 0, (
             f"Found {len(read_digins_calls)} call(s) to read_digins at line(s): "
             f"{read_digins_calls}. These should be removed as dig-ins are now "
             f"loaded via dig_in_frame in blech_init.py"
         )
-        
+
         assert len(read_digins_single_file_calls) == 0, (
             f"Found {len(read_digins_single_file_calls)} call(s) to "
             f"read_digins_single_file at line(s): {read_digins_single_file_calls}. "
@@ -65,29 +65,29 @@ class TestBlechReloadAmpDigs:
         """Test that read_electrode_channels is still called in the file"""
         # Read the source file
         file_path = os.path.join(
-            os.path.dirname(__file__), 
-            '..', 
-            'utils', 
+            os.path.dirname(__file__),
+            '..',
+            'utils',
             'blech_reload_amp_digs.py'
         )
-        
+
         with open(file_path, 'r') as f:
             source = f.read()
-        
+
         # Parse the source code
         tree = ast.parse(source)
-        
+
         # Find function calls to read_electrode_channels
         read_electrode_channels_calls = []
-        
+
         for node in ast.walk(tree):
             if isinstance(node, ast.Call):
                 if isinstance(node.func, ast.Attribute):
-                    if (isinstance(node.func.value, ast.Name) and 
+                    if (isinstance(node.func.value, ast.Name) and
                         node.func.value.id == 'read_file' and
-                        node.func.attr == 'read_electrode_channels'):
+                            node.func.attr == 'read_electrode_channels'):
                         read_electrode_channels_calls.append(node.lineno)
-        
+
         # Assert that read_electrode_channels is still called
         assert len(read_electrode_channels_calls) > 0, (
             "read_electrode_channels should still be called in "
@@ -98,29 +98,29 @@ class TestBlechReloadAmpDigs:
         """Test that read_emg_channels is still called in the file"""
         # Read the source file
         file_path = os.path.join(
-            os.path.dirname(__file__), 
-            '..', 
-            'utils', 
+            os.path.dirname(__file__),
+            '..',
+            'utils',
             'blech_reload_amp_digs.py'
         )
-        
+
         with open(file_path, 'r') as f:
             source = f.read()
-        
+
         # Parse the source code
         tree = ast.parse(source)
-        
+
         # Find function calls to read_emg_channels
         read_emg_channels_calls = []
-        
+
         for node in ast.walk(tree):
             if isinstance(node, ast.Call):
                 if isinstance(node.func, ast.Attribute):
-                    if (isinstance(node.func.value, ast.Name) and 
+                    if (isinstance(node.func.value, ast.Name) and
                         node.func.value.id == 'read_file' and
-                        node.func.attr == 'read_emg_channels'):
+                            node.func.attr == 'read_emg_channels'):
                         read_emg_channels_calls.append(node.lineno)
-        
+
         # Assert that read_emg_channels is still called
         assert len(read_emg_channels_calls) > 0, (
             "read_emg_channels should still be called in "

--- a/utils/blech_reload_amp_digs.py
+++ b/utils/blech_reload_amp_digs.py
@@ -140,13 +140,13 @@ electrode_layout_frame = pd.read_csv(layout_path)
 
 
 # Read data files, and append to electrode arrays
+# NOTE: Dig-ins are now loaded into dig_in_frame via blech_init.py
+# so we no longer need to reload them here
 if file_type == ['one file per channel']:
-    read_file.read_digins(hdf5_name, dig_in, dig_in_list)
     read_file.read_electrode_channels(hdf5_name, electrode_layout_frame)
     if len(emg_channels) > 0:
         read_file.read_emg_channels(hdf5_name, electrode_layout_frame)
 elif file_type == ['one file per signal type']:
-    read_file.read_digins_single_file(hdf5_name, dig_in, dig_in_list)
     # This next line takes care of both electrodes and emgs
     read_file.read_electrode_emg_channels_single_file(
         hdf5_name, electrode_layout_frame, electrodes_list, num_recorded_samples, emg_channels)


### PR DESCRIPTION
## Fix for Issue #799: "No EMG Data found"

### Problem
Running `blech_reload_amp_digs.py` was causing an error because it was trying to call `read_digins` and `read_digins_single_file` functions that no longer exist in `read_file.py`.

```
AttributeError: module 'utils.read_file' has no attribute 'read_digins'
```

### Root Cause
Dig-ins are now loaded into `dig_in_frame` via `blech_init.py` (see lines 377 and 382 in `blech_init.py` which are already commented out), so the calls to `read_digins` and `read_digins_single_file` in `blech_reload_amp_digs.py` are no longer needed and cause errors.

### Solution
Removed the calls to `read_file.read_digins()` and `read_file.read_digins_single_file()` from `utils/blech_reload_amp_digs.py`. The electrode and EMG channel reading functions are still called as expected.

### Changes
- Modified `utils/blech_reload_amp_digs.py`: Removed dig-in loading calls
- Added test `tests/test_blech_reload_amp_digs.py` to verify the fix

### Test
A test was added to verify that:
1. No calls to `read_digins` or `read_digins_single_file` exist in the file
2. Calls to `read_electrode_channels` and `read_emg_channels` are still present