### PR TITLE
fix docs: Update import paths to use blech_clust.utils and array_lists for LFP data

### DIFF
--- a/docs/getting-started/migration-guide/removed-features.md
+++ b/docs/getting-started/migration-guide/removed-features.md
@@ -69,8 +69,8 @@ The entire `LFP_analysis/` directory has been removed:
 LFP functionality is now available through the `ephys_data` module:
 
 ```python
-from utils.ephys_data.ephys_data import ephys_data
-from utils.ephys_data import lfp_processing
+from blech_clust.utils.ephys_data.ephys_data import ephys_data
+from blech_clust.utils.ephys_data import lfp_processing
 
 # Load data
 data = ephys_data(data_dir='/path/to/data')
@@ -87,7 +87,7 @@ data.lfp_params = {
 # Extract and load LFPs
 data.extract_lfps()
 data.get_lfps()
-lfp_data = data.lfp_array
+lfp_data = data.lfp_array_list
 ```
 
 See [Ephys Data Reference](../../reference/ephys-data.md) for complete documentation.
@@ -147,7 +147,7 @@ The `additional_analyses/` directory has been removed:
 Basic palatability analysis is available through the `ephys_data` module:
 
 ```python
-from utils.ephys_data.ephys_data import ephys_data
+from blech_clust.utils.ephys_data.ephys_data import ephys_data
 
 data = ephys_data(data_dir='/path/to/data')
 data.get_unit_descriptors()
@@ -180,7 +180,7 @@ The `laser_effect_analysis/` directory has been removed:
 Laser trial separation is available through the `ephys_data` module:
 
 ```python
-from utils.ephys_data.ephys_data import ephys_data
+from blech_clust.utils.ephys_data.ephys_data import ephys_data
 
 data = ephys_data(data_dir='/path/to/data')
 data.get_spikes()

--- a/docs/reference/ephys-data.md
+++ b/docs/reference/ephys-data.md
@@ -19,7 +19,7 @@ Implementation of Bayesian Adaptive Kernel Smoother for firing rate estimation.
 ## Basic Usage
 
 ```python
-from utils.ephys_data.ephys_data import ephys_data
+from blech_clust.utils.ephys_data.ephys_data import ephys_data
 
 # Initialize with data directory
 data = ephys_data(data_dir='/path/to/data')
@@ -61,11 +61,11 @@ firing = data.firing_array # 4D array of firing rates
 ### LFP Analysis
 
 ```python
-# Access LFP data
-lfps = data.lfp_array     # Raw LFP data
-stft = data.stft_array    # Complex Spectrograms
-amplitude = data.amplitude_array # STFT Amplitude (power)
-phase = data.phase_array  # STFT Phase
+# Access LFP data (returns list of arrays, one per taste)
+lfps = data.lfp_array_list     # Raw LFP data (list of arrays)
+stft = data.stft_array_list    # Complex Spectrograms (list of arrays)
+amplitude = data.amplitude_array_list # STFT Amplitude (power) (list of arrays)
+phase = data.phase_array_list  # STFT Phase (list of arrays)
 ```
 
 ### Region-Based Analysis
@@ -124,7 +124,7 @@ pal_array = data.pal_array # Palatability correlations
 ### Ephys Data Processing
 
 ```python
-from utils.ephys_data.ephys_data import ephys_data
+from blech_clust.utils.ephys_data.ephys_data import ephys_data
 import numpy as np
 import matplotlib.pyplot as plt
 
@@ -175,7 +175,7 @@ plt.show()
 ```python
 import numpy as np
 import matplotlib.pyplot as plt
-from utils.ephys_data.visualize import raster, firing_overview
+from blech_clust.utils.ephys_data.visualize import raster, firing_overview
 
 # Create sample spike data (binary array where 1 indicates a spike)
 spike_array = np.zeros((10, 100))  # 10 trials, 100 time points
@@ -223,8 +223,8 @@ plt.show()
 ### LFP Processing
 
 ```python
-from utils.ephys_data.ephys_data import ephys_data
-from utils.ephys_data import lfp_processing
+from blech_clust.utils.ephys_data.ephys_data import ephys_data
+from blech_clust.utils.ephys_data import lfp_processing
 import numpy as np
 import matplotlib.pyplot as plt
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -51,7 +51,7 @@ Located in `emg/`, these handle EMG signal analysis:
 from utils.blech_utils import Tee, path_handler, imp_metadata
 
 # Import ephys data tools
-from utils.ephys_data import ephys_data
+from blech_clust.utils.ephys_data import ephys_data
 
 # Import clustering utilities
 from utils.clustering import clustering
@@ -61,7 +61,7 @@ from utils.clustering import clustering
 
 ```python
 # Load experimental data
-from utils.ephys_data import ephys_data
+from blech_clust.utils.ephys_data import ephys_data
 
 # Create data handler
 data = ephys_data('/path/to/data')

--- a/utils/ephys_data/README.md
+++ b/utils/ephys_data/README.md
@@ -7,7 +7,7 @@ The `ephys_data` module provides tools for analyzing electrophysiology data, inc
 ## Quick Start
 
 ```python
-from utils.ephys_data.ephys_data import ephys_data
+from blech_clust.utils.ephys_data.ephys_data import ephys_data
 
 # Initialize with data directory
 data = ephys_data(data_dir='/path/to/data')


### PR DESCRIPTION
## Summary
This PR fixes issue #798 by updating the documentation to use the correct import path and array_lists for LFP data.

### Changes Made

1. **Updated import paths**: Changed all documentation files to use the correct import path:
   - `from blech_clust.utils.ephys_data.ephys_data import ephys_data` (instead of `from utils.ephys_data.ephys_data import ephys_data`)

2. **Updated LFP analysis code examples**: Changed to use the `array_lists` attributes as mentioned in the comment:
   - `lfp_array_list` instead of `lfp_array`
   - `stft_array_list` instead of `stft_array`
   - `amplitude_array_list` instead of `amplitude_array`
   - `phase_array_list` instead of `phase_array`

### Files Updated
- `docs/reference/ephys-data.md` - Main reference documentation
- `docs/reference/index.md` - Reference index page
- `docs/getting-started/migration-guide/removed-features.md` - Migration guide
- `utils/ephys_data/README.md` - Module README